### PR TITLE
Adiciona cadastro de responsáveis e clientes

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -3,3 +3,29 @@ function carregarDetalhes(id) {
         $('#detalhesConteudo').html(data);
     });
 }
+
+$(function() {
+    $('#formResponsavel').on('submit', function(e) {
+        e.preventDefault();
+        $.post('salvar_responsavel.php', $(this).serialize(), function(resp) {
+            if (resp.success) {
+                $('#responsavelModal').modal('hide');
+                location.reload();
+            } else {
+                $('#respAlert').html('<div class="alert alert-warning alert-dismissible fade show" role="alert">'+resp.message+'<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>');
+            }
+        }, 'json');
+    });
+
+    $('#formCliente').on('submit', function(e) {
+        e.preventDefault();
+        $.post('salvar_cliente.php', $(this).serialize(), function(resp) {
+            if (resp.success) {
+                $('#clienteModal').modal('hide');
+                location.reload();
+            } else {
+                $('#cliAlert').html('<div class="alert alert-warning alert-dismissible fade show" role="alert">'+resp.message+'<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>');
+            }
+        }, 'json');
+    });
+});

--- a/index.php
+++ b/index.php
@@ -29,6 +29,7 @@ foreach ($statuses as $s) {
         <a class="navbar-brand" href="#">PDVTarefas</a>
         <div class="d-flex">
             <button class="btn btn-light me-2" data-bs-toggle="modal" data-bs-target="#novaTarefaModal">Nova Tarefa</button>
+            <button class="btn btn-light me-2" data-bs-toggle="modal" data-bs-target="#cadastroModal">Cadastro</button>
             <button class="btn btn-light">Configurações</button>
         </div>
     </div>
@@ -92,6 +93,72 @@ foreach ($statuses as $s) {
             }
             ?>
           </select>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="submit" class="btn btn-primary">Salvar</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<!-- Modal Cadastro -->
+<div class="modal fade" id="cadastroModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Cadastro</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body text-center">
+        <button class="btn btn-primary me-2" data-bs-target="#responsavelModal" data-bs-toggle="modal" data-bs-dismiss="modal">Responsável</button>
+        <button class="btn btn-primary" data-bs-target="#clienteModal" data-bs-toggle="modal" data-bs-dismiss="modal">Cliente</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Modal Responsável -->
+<div class="modal fade" id="responsavelModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <form class="modal-content" id="formResponsavel">
+      <div class="modal-header">
+        <h5 class="modal-title">Cadastrar Responsável</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div id="respAlert"></div>
+        <div class="mb-3">
+          <label class="form-label">Nome</label>
+          <input type="text" class="form-control" name="nome" required>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="submit" class="btn btn-primary">Salvar</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<!-- Modal Cliente -->
+<div class="modal fade" id="clienteModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <form class="modal-content" id="formCliente">
+      <div class="modal-header">
+        <h5 class="modal-title">Cadastrar Cliente</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div id="cliAlert"></div>
+        <div class="mb-3">
+          <label class="form-label">CNPJ</label>
+          <input type="text" class="form-control" name="cnpj" required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Nome</label>
+          <input type="text" class="form-control" name="nome" required>
         </div>
       </div>
       <div class="modal-footer">

--- a/init_db.php
+++ b/init_db.php
@@ -9,6 +9,7 @@ $queries = [
     );",
     "CREATE TABLE IF NOT EXISTS clientes (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
+        cnpj TEXT UNIQUE,
         nome TEXT NOT NULL
     );",
     "CREATE TABLE IF NOT EXISTS tarefas (

--- a/salvar_cliente.php
+++ b/salvar_cliente.php
@@ -1,0 +1,23 @@
+<?php
+require 'config.php';
+
+$cnpj = trim($_POST['cnpj'] ?? '');
+$nome = trim($_POST['nome'] ?? '');
+
+if ($cnpj === '' || $nome === '') {
+    echo json_encode(['success' => false, 'message' => 'CNPJ e nome s\u00e3o obrigat\u00f3rios.']);
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT COUNT(*) FROM clientes WHERE cnpj = ?');
+$stmt->execute([$cnpj]);
+if ($stmt->fetchColumn() > 0) {
+    echo json_encode(['success' => false, 'message' => 'CNPJ j\u00e1 cadastrado.']);
+    exit;
+}
+
+$stmt = $pdo->prepare('INSERT INTO clientes (cnpj, nome) VALUES (?, ?)');
+$stmt->execute([$cnpj, $nome]);
+
+echo json_encode(['success' => true]);
+?>

--- a/salvar_responsavel.php
+++ b/salvar_responsavel.php
@@ -1,0 +1,22 @@
+<?php
+require 'config.php';
+
+$nome = trim($_POST['nome'] ?? '');
+
+if ($nome === '') {
+    echo json_encode(['success' => false, 'message' => 'Nome \u00e9 obrigat\u00f3rio.']);
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT COUNT(*) FROM responsaveis WHERE nome = ?');
+$stmt->execute([$nome]);
+if ($stmt->fetchColumn() > 0) {
+    echo json_encode(['success' => false, 'message' => 'Respons\u00e1vel j\u00e1 cadastrado.']);
+    exit;
+}
+
+$stmt = $pdo->prepare('INSERT INTO responsaveis (nome) VALUES (?)');
+$stmt->execute([$nome]);
+
+echo json_encode(['success' => true]);
+?>


### PR DESCRIPTION
## Summary
- adiciona botão `Cadastro` ao menu
- cria modais para cadastro de Responsável e Cliente
- adiciona scripts PHP para salvar os cadastros
- atualiza `init_db.php` com campo `cnpj` e chave única em clientes
- implementa Ajax para salvar registros e exibir alertas

## Testing
- `php -l index.php` *(falhou: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684baf9b426c8325a2b18784be27d52c