### PR TITLE
Adicionar campos de data e status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDVTarefas
 
-Projeto simples de controle de tarefas em PHP com layout responsivo utilizando Bootstrap.
+Projeto simples de controle de tarefas em PHP com layout responsivo utilizando Bootstrap. Agora as tarefas possuem registro de data/hora de criação e atualização, além de mudança de situação via arraste.
 
 ## Estrutura de Pastas
 ```

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -7,3 +7,8 @@ body {
 .card {
     cursor: pointer;
 }
+.card-placeholder {
+    border: 2px dashed #ccc;
+    height: 60px;
+    margin-bottom: 0.5rem;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -28,4 +28,26 @@ $(function() {
             }
         }, 'json');
     });
+
+    // Delegação para formulário de atualização de status
+    $(document).on('submit', '#formStatus', function(e) {
+        e.preventDefault();
+        $.post('atualizar_status.php', $(this).serialize(), function(resp) {
+            if (resp.success) {
+                $('#detalhesModal').modal('hide');
+                location.reload();
+            }
+        }, 'json');
+    });
+
+    // Drag and drop das tarefas
+    $('.tarefa-col').sortable({
+        connectWith: '.tarefa-col',
+        placeholder: 'card-placeholder',
+        receive: function(event, ui) {
+            var id = ui.item.data('id');
+            var status = $(this).data('status');
+            $.post('atualizar_status.php', {id: id, status: status});
+        }
+    }).disableSelection();
 });

--- a/atualizar_status.php
+++ b/atualizar_status.php
@@ -1,0 +1,13 @@
+<?php
+require 'config.php';
+
+$id = $_POST['id'] ?? 0;
+$status = $_POST['status'] ?? '';
+
+if ($id && $status) {
+    $stmt = $pdo->prepare('UPDATE tarefas SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?');
+    $stmt->execute([$status, $id]);
+    echo json_encode(['success' => true]);
+} else {
+    echo json_encode(['success' => false]);
+}

--- a/detalhes_tarefa.php
+++ b/detalhes_tarefa.php
@@ -17,6 +17,7 @@ if (!$tarefa) {
 $sub = $pdo->prepare('SELECT * FROM subtarefas WHERE tarefa_id = ?');
 $sub->execute([$id]);
 $subtarefas = $sub->fetchAll(PDO::FETCH_ASSOC);
+$statuses = ['A fazer','Fazendo','Agendado','Aguardando','Finalizado'];
 ?>
 <div class="modal-header">
   <h5 class="modal-title">Detalhes da Tarefa</h5>
@@ -27,6 +28,8 @@ $subtarefas = $sub->fetchAll(PDO::FETCH_ASSOC);
   <p><?= nl2br(htmlspecialchars($tarefa['detalhes'])) ?></p>
   <p><strong>Responsável:</strong> <?= htmlspecialchars($tarefa['responsavel'] ?? 'N/A') ?></p>
   <p><strong>Cliente:</strong> <?= htmlspecialchars($tarefa['cliente'] ?? 'N/A') ?></p>
+  <p><strong>Criada em:</strong> <?= date('d/m/Y H:i', strtotime($tarefa['created_at'])) ?></p>
+  <p><strong>Atualizada em:</strong> <?= date('d/m/Y H:i', strtotime($tarefa['updated_at'])) ?></p>
   <?php if ($subtarefas): ?>
     <h6>Checklist</h6>
     <ul>
@@ -35,6 +38,18 @@ $subtarefas = $sub->fetchAll(PDO::FETCH_ASSOC);
       <?php endforeach; ?>
     </ul>
   <?php endif; ?>
+  <form id="formStatus">
+    <input type="hidden" name="id" value="<?= $tarefa['id'] ?>">
+    <div class="mb-3">
+      <label class="form-label">Situação</label>
+      <select class="form-select" name="status">
+        <?php foreach ($statuses as $s): ?>
+          <option value="<?= $s ?>" <?= $s == $tarefa['status'] ? 'selected' : '' ?>><?= $s ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <button type="submit" class="btn btn-primary">Salvar Situação</button>
+  </form>
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>

--- a/salvar_tarefa.php
+++ b/salvar_tarefa.php
@@ -5,10 +5,15 @@ $titulo = $_POST['titulo'] ?? '';
 $detalhes = $_POST['detalhes'] ?? '';
 $responsavel_id = $_POST['responsavel_id'] ?: null;
 $cliente_id = $_POST['cliente_id'] ?: null;
+$created_at = $_POST['created_at'] ?? date('Y-m-d H:i:s');
+
+if ($created_at) {
+    $created_at = str_replace('T', ' ', $created_at);
+}
 
 if ($titulo) {
-    $stmt = $pdo->prepare('INSERT INTO tarefas (titulo, detalhes, responsavel_id, cliente_id, status) VALUES (?, ?, ?, ?, ?)');
-    $stmt->execute([$titulo, $detalhes, $responsavel_id, $cliente_id, 'A fazer']);
+    $stmt = $pdo->prepare('INSERT INTO tarefas (titulo, detalhes, responsavel_id, cliente_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)');
+    $stmt->execute([$titulo, $detalhes, $responsavel_id, $cliente_id, 'A fazer', $created_at, $created_at]);
 }
 
 header('Location: index.php');


### PR DESCRIPTION
## Summary
- permitir informar data e hora de criação ao cadastrar tarefa
- exibir situação de atraso das tarefas
- atualizar situação pelo detalhamento ou arrastando no kanban
- registrar data e hora de atualização no banco
- carregar jQuery UI e estilos para drag and drop

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bb421fb04832589b16aaa4ba0084e