### PR TITLE
Correção de drag-and-drop e fuso horário

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -41,13 +41,29 @@ $(function() {
     });
 
     // Drag and drop das tarefas
+    var isDragging = false;
     $('.tarefa-col').sortable({
         connectWith: '.tarefa-col',
         placeholder: 'card-placeholder',
+        start: function() {
+            isDragging = true;
+        },
+        stop: function() {
+            // pequeno delay para diferenciar clique de arraste
+            setTimeout(function(){ isDragging = false; }, 100);
+        },
         receive: function(event, ui) {
             var id = ui.item.data('id');
             var status = $(this).data('status');
             $.post('atualizar_status.php', {id: id, status: status});
         }
     }).disableSelection();
+
+    // Impede abertura do modal quando o card está sendo arrastado
+    $(document).on('click', '.tarefa-card', function(e){
+        if(isDragging){
+            e.preventDefault();
+            e.stopImmediatePropagation();
+        }
+    });
 });

--- a/atualizar_status.php
+++ b/atualizar_status.php
@@ -5,8 +5,10 @@ $id = $_POST['id'] ?? 0;
 $status = $_POST['status'] ?? '';
 
 if ($id && $status) {
-    $stmt = $pdo->prepare('UPDATE tarefas SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?');
-    $stmt->execute([$status, $id]);
+    // Atualiza a situação e registra a data/hora de alteração
+    $now = date('Y-m-d H:i:s');
+    $stmt = $pdo->prepare('UPDATE tarefas SET status = ?, updated_at = ? WHERE id = ?');
+    $stmt->execute([$status, $now, $id]);
     echo json_encode(['success' => true]);
 } else {
     echo json_encode(['success' => false]);

--- a/config.php
+++ b/config.php
@@ -3,6 +3,9 @@
 
 $databasePath = __DIR__ . '/db/pdvtarefas.db';
 
+// Define o fuso-horário padrão para evitar divergência na gravação de datas
+date_default_timezone_set('America/Sao_Paulo');
+
 try {
     $pdo = new PDO('sqlite:' . $databasePath);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/salvar_tarefa.php
+++ b/salvar_tarefa.php
@@ -10,10 +10,11 @@ $created_at = $_POST['created_at'] ?? date('Y-m-d H:i:s');
 if ($created_at) {
     $created_at = str_replace('T', ' ', $created_at);
 }
+$updated_at = $created_at;
 
 if ($titulo) {
     $stmt = $pdo->prepare('INSERT INTO tarefas (titulo, detalhes, responsavel_id, cliente_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)');
-    $stmt->execute([$titulo, $detalhes, $responsavel_id, $cliente_id, 'A fazer', $created_at, $created_at]);
+    $stmt->execute([$titulo, $detalhes, $responsavel_id, $cliente_id, 'A fazer', $created_at, $updated_at]);
 }
 
 header('Location: index.php');


### PR DESCRIPTION
## Resumo
- ajusta fuso horário para America/Sao_Paulo
- corrige atualização de data em `atualizar_status.php`
- corrige salvamento de data em `salvar_tarefa.php`
- melhora arraste e solte com controle de clique e flag `isDragging`

## Testes
- `php -v` *(falhou: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bb902b8e88325987ad56c089b5693