### PR TITLE
Fix drag-and-drop when target column is empty

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -12,3 +12,8 @@ body {
     height: 60px;
     margin-bottom: 0.5rem;
 }
+
+/* Permite soltar tarefas mesmo quando a coluna está vazia */
+.tarefa-col {
+    min-height: 70px;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -45,6 +45,7 @@ $(function() {
     $('.tarefa-col').sortable({
         connectWith: '.tarefa-col',
         placeholder: 'card-placeholder',
+        forcePlaceholderSize: true,
         start: function() {
             isDragging = true;
         },


### PR DESCRIPTION
## Summary
- add min-height for task columns so empty columns are droppable
- keep placeholder size so dragging into empty columns works

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bbb5481208325a1e2fe77b72b20d4