### PR TITLE
Adicionar edição e exclusão de tarefas

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,6 +1,9 @@
 function carregarDetalhes(id) {
     $.get('detalhes_tarefa.php', {id: id}, function(data) {
         $('#detalhesConteudo').html(data);
+        if (typeof Quill !== 'undefined') {
+            window.quill = new Quill('#comentarioEditor', {theme: 'snow'});
+        }
     });
 }
 
@@ -38,6 +41,50 @@ $(function() {
                 location.reload();
             }
         }, 'json');
+    });
+
+    // Atualização de detalhes
+    $(document).on('submit', '#formTarefaDetalhes', function(e){
+        e.preventDefault();
+        $.post('atualizar_tarefa.php', $(this).serialize(), function(resp){
+            if(resp.success){
+                $('#detalhesModal').modal('hide');
+                location.reload();
+            }
+        }, 'json');
+    });
+
+    // Salvar comentário
+    $(document).on('click', '#btnSalvarComentario', function(){
+        var id = $('#formTarefaDetalhes input[name=id]').val();
+        var texto = window.quill.root.innerHTML;
+        $.post('salvar_comentario.php', {tarefa_id: id, texto: texto}, function(resp){
+            if(resp.success){
+                carregarDetalhes(id);
+            }
+        }, 'json');
+    });
+
+    // Excluir tarefa
+    $(document).on('click', '#btnExcluirTarefa', function(){
+        var id = $('#formTarefaDetalhes input[name=id]').val();
+        var titulo = $('#detalhesTitulo').val();
+        Swal.fire({
+            title: 'Excluir "'+titulo+'"?',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonText: 'Sim',
+            cancelButtonText: 'Não'
+        }).then(function(result){
+            if(result.isConfirmed){
+                $.post('excluir_tarefa.php', {id:id}, function(resp){
+                    if(resp.success){
+                        $('#detalhesModal').modal('hide');
+                        location.reload();
+                    }
+                }, 'json');
+            }
+        });
     });
 
     // Drag and drop das tarefas

--- a/atualizar_tarefa.php
+++ b/atualizar_tarefa.php
@@ -1,0 +1,17 @@
+<?php
+require 'config.php';
+
+$id = $_POST['id'] ?? 0;
+$detalhes = $_POST['detalhes'] ?? '';
+$responsavel_id = $_POST['responsavel_id'] ?: null;
+$cliente_id = $_POST['cliente_id'] ?: null;
+
+if ($id) {
+    $now = date('Y-m-d H:i:s');
+    $stmt = $pdo->prepare('UPDATE tarefas SET detalhes = ?, responsavel_id = ?, cliente_id = ?, updated_at = ? WHERE id = ?');
+    $stmt->execute([$detalhes, $responsavel_id, $cliente_id, $now, $id]);
+    echo json_encode(['success' => true]);
+} else {
+    echo json_encode(['success' => false]);
+}
+?>

--- a/detalhes_tarefa.php
+++ b/detalhes_tarefa.php
@@ -18,16 +18,48 @@ $sub = $pdo->prepare('SELECT * FROM subtarefas WHERE tarefa_id = ?');
 $sub->execute([$id]);
 $subtarefas = $sub->fetchAll(PDO::FETCH_ASSOC);
 $statuses = ['A fazer','Fazendo','Agendado','Aguardando','Finalizado'];
+$responsaveis = $pdo->query('SELECT id, nome FROM responsaveis')->fetchAll(PDO::FETCH_ASSOC);
+$clientes = $pdo->query('SELECT id, nome FROM clientes')->fetchAll(PDO::FETCH_ASSOC);
+$com = $pdo->prepare('SELECT texto, created_at FROM comentarios WHERE tarefa_id = ? ORDER BY id DESC');
+$com->execute([$id]);
+$comentarios = $com->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <div class="modal-header">
   <h5 class="modal-title">Detalhes da Tarefa</h5>
   <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
 </div>
 <div class="modal-body">
-  <h6><?= htmlspecialchars($tarefa['titulo']) ?></h6>
-  <p><?= nl2br(htmlspecialchars($tarefa['detalhes'])) ?></p>
-  <p><strong>Responsável:</strong> <?= htmlspecialchars($tarefa['responsavel'] ?? 'N/A') ?></p>
-  <p><strong>Cliente:</strong> <?= htmlspecialchars($tarefa['cliente'] ?? 'N/A') ?></p>
+  <form id="formTarefaDetalhes">
+    <input type="hidden" name="id" value="<?= $tarefa['id'] ?>">
+    <div class="mb-3">
+      <label class="form-label">Título</label>
+      <input type="text" class="form-control" id="detalhesTitulo" name="titulo" value="<?= htmlspecialchars($tarefa['titulo']) ?>" readonly>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Detalhes</label>
+      <textarea class="form-control" name="detalhes" rows="3"><?= htmlspecialchars($tarefa['detalhes']) ?></textarea>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Responsável</label>
+      <select class="form-select" name="responsavel_id">
+        <option value="">Selecione...</option>
+        <?php foreach ($responsaveis as $r): ?>
+          <option value="<?= $r['id'] ?>" <?= $tarefa['responsavel_id'] == $r['id'] ? 'selected' : '' ?>><?= htmlspecialchars($r['nome']) ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Cliente</label>
+      <select class="form-select" name="cliente_id">
+        <option value="">Selecione...</option>
+        <?php foreach ($clientes as $c): ?>
+          <option value="<?= $c['id'] ?>" <?= $tarefa['cliente_id'] == $c['id'] ? 'selected' : '' ?>><?= htmlspecialchars($c['nome']) ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <button type="submit" class="btn btn-primary mb-3">Salvar Alterações</button>
+  </form>
+
   <p><strong>Criada em:</strong> <?= date('d/m/Y H:i', strtotime($tarefa['created_at'])) ?></p>
   <p><strong>Atualizada em:</strong> <?= date('d/m/Y H:i', strtotime($tarefa['updated_at'])) ?></p>
   <?php if ($subtarefas): ?>
@@ -37,7 +69,7 @@ $statuses = ['A fazer','Fazendo','Agendado','Aguardando','Finalizado'];
         <li><?= htmlspecialchars($s['descricao']) ?> <?= $s['concluida'] ? '(Ok)' : '' ?></li>
       <?php endforeach; ?>
     </ul>
-    <?php endif; ?>
+  <?php endif; ?>
   <form id="formStatus">
     <input type="hidden" name="id" value="<?= $tarefa['id'] ?>">
     <div class="mb-3">
@@ -48,9 +80,22 @@ $statuses = ['A fazer','Fazendo','Agendado','Aguardando','Finalizado'];
         <?php endforeach; ?>
       </select>
     </div>
-    <button type="submit" class="btn btn-primary">Salvar Situação</button>
+    <button type="submit" class="btn btn-secondary">Salvar Situação</button>
   </form>
+
+  <h6 class="mt-3">Comentários</h6>
+  <div id="listaComentarios">
+    <?php foreach ($comentarios as $c): ?>
+      <div class="border p-2 mb-2">
+        <div class="small text-muted"><?= date('d/m/Y H:i', strtotime($c['created_at'])) ?></div>
+        <div><?= $c['texto'] ?></div>
+      </div>
+    <?php endforeach; ?>
+  </div>
+  <div id="comentarioEditor" style="height:100px;" class="mb-2"></div>
+  <button type="button" class="btn btn-success" id="btnSalvarComentario">Salvar Comentário</button>
 </div>
 <div class="modal-footer">
+  <button type="button" class="btn btn-danger me-auto" id="btnExcluirTarefa">Excluir</button>
   <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
 </div>

--- a/excluir_tarefa.php
+++ b/excluir_tarefa.php
@@ -1,0 +1,14 @@
+<?php
+require 'config.php';
+
+$id = $_POST['id'] ?? 0;
+
+if ($id) {
+    $pdo->prepare('DELETE FROM comentarios WHERE tarefa_id = ?')->execute([$id]);
+    $pdo->prepare('DELETE FROM subtarefas WHERE tarefa_id = ?')->execute([$id]);
+    $pdo->prepare('DELETE FROM tarefas WHERE id = ?')->execute([$id]);
+    echo json_encode(['success' => true]);
+} else {
+    echo json_encode(['success' => false]);
+}
+?>

--- a/index.php
+++ b/index.php
@@ -22,6 +22,7 @@ foreach ($statuses as $s) {
     <title>PDVTarefas</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="assets/css/style.css">
+    <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
@@ -208,6 +209,8 @@ foreach ($statuses as $s) {
 <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
 <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+<script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
 <script src="assets/js/app.js"></script>
 </body>
 </html>

--- a/init_db.php
+++ b/init_db.php
@@ -27,6 +27,12 @@ $queries = [
         tarefa_id INTEGER NOT NULL,
         descricao TEXT NOT NULL,
         concluida INTEGER NOT NULL DEFAULT 0
+    );",
+    "CREATE TABLE IF NOT EXISTS comentarios (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        tarefa_id INTEGER NOT NULL,
+        texto TEXT NOT NULL,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
     );"
 ];
 

--- a/salvar_comentario.php
+++ b/salvar_comentario.php
@@ -1,0 +1,15 @@
+<?php
+require 'config.php';
+
+$tarefa_id = $_POST['tarefa_id'] ?? 0;
+$texto = $_POST['texto'] ?? '';
+
+if ($tarefa_id && $texto !== '') {
+    $now = date('Y-m-d H:i:s');
+    $stmt = $pdo->prepare('INSERT INTO comentarios (tarefa_id, texto, created_at) VALUES (?, ?, ?)');
+    $stmt->execute([$tarefa_id, $texto, $now]);
+    echo json_encode(['success' => true]);
+} else {
+    echo json_encode(['success' => false]);
+}
+?>


### PR DESCRIPTION
## Resumo
- permitir editar detalhes, responsável e cliente na visualização de tarefa
- incluir comentários formatados via Quill e gravá-los no banco
- adicionar botão de exclusão com confirmação SweetAlert2
- criar rotas PHP para atualizar, excluir e comentar tarefas
- suporte a tabela `comentarios` no banco
- atualizar scripts JS

## Testes
- sem testes automatizados

------
https://chatgpt.com/codex/tasks/task_e_684bbe0a4d288325a638dc37d9135b16