### PR TITLE
Implementa busca de cliente ao criar tarefa

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -114,4 +114,24 @@ $(function() {
             e.stopImmediatePropagation();
         }
     });
+
+    if(typeof clientesData !== 'undefined'){
+        var clientesMap = clientesData.map(function(c){
+            return {label: c.nome + ' (' + c.cnpj + ')', value: c.id};
+        });
+        $('#clienteBusca').autocomplete({
+            source: clientesMap,
+            minLength: 0,
+            select: function(event, ui){
+                $('#cliente_id').val(ui.item.value);
+            },
+            change: function(event, ui){
+                if(!ui.item){
+                    $('#cliente_id').val('');
+                }
+            }
+        }).on('focus', function(){
+            $(this).autocomplete('search', $(this).val());
+        });
+    }
 });

--- a/index.php
+++ b/index.php
@@ -13,6 +13,9 @@ $tarefas = [];
 foreach ($statuses as $s) {
     $tarefas[$s] = obterTarefasPorStatus($pdo, $s);
 }
+
+$responsaveis = $pdo->query('SELECT id, nome FROM responsaveis')->fetchAll(PDO::FETCH_ASSOC);
+$clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <!DOCTYPE html>
 <html lang="pt-br">
@@ -98,8 +101,7 @@ foreach ($statuses as $s) {
           <select class="form-select" name="responsavel_id">
             <option value="">Selecione...</option>
             <?php
-            $resp = $pdo->query('SELECT id, nome FROM responsaveis')->fetchAll(PDO::FETCH_ASSOC);
-            foreach ($resp as $r) {
+            foreach ($responsaveis as $r) {
                 echo '<option value="'.$r['id'].'">'.htmlspecialchars($r['nome']).'</option>';
             }
             ?>
@@ -107,15 +109,8 @@ foreach ($statuses as $s) {
         </div>
         <div class="mb-3">
           <label class="form-label">Cliente</label>
-          <select class="form-select" name="cliente_id">
-            <option value="">Selecione...</option>
-            <?php
-            $cli = $pdo->query('SELECT id, nome FROM clientes')->fetchAll(PDO::FETCH_ASSOC);
-            foreach ($cli as $c) {
-                echo '<option value="'.$c['id'].'">'.htmlspecialchars($c['nome']).'</option>';
-            }
-            ?>
-          </select>
+          <input type="hidden" name="cliente_id" id="cliente_id">
+          <input type="text" class="form-control" id="clienteBusca" placeholder="Digite o nome ou CNPJ">
         </div>
         <div class="mb-3">
           <label class="form-label">Data e Hora de Criação</label>
@@ -211,6 +206,9 @@ foreach ($statuses as $s) {
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
+<script>
+var clientesData = <?php echo json_encode($clientes); ?>;
+</script>
 <script src="assets/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Resumo
- consulta lista de clientes e responsáveis antes de renderizar a página
- adiciona campo de pesquisa para clientes na criação de tarefas
- disponibiliza lista de clientes no JavaScript
- configura autocomplete jQuery UI para filtrar por nome ou CNPJ

## Testes
- `php -v` *(falha: comando não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_684c1131faf083259edacb93b8c40847