### PR TITLE
Implementa lista e edição para cadastro

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -10,7 +10,9 @@ function carregarDetalhes(id) {
 $(function() {
     $('#formResponsavel').on('submit', function(e) {
         e.preventDefault();
-        $.post('salvar_responsavel.php', $(this).serialize(), function(resp) {
+        var id = $(this).find('input[name=id]').val();
+        var url = id ? 'atualizar_responsavel.php' : 'salvar_responsavel.php';
+        $.post(url, $(this).serialize(), function(resp) {
             if (resp.success) {
                 $('#responsavelModal').modal('hide');
                 location.reload();
@@ -22,7 +24,9 @@ $(function() {
 
     $('#formCliente').on('submit', function(e) {
         e.preventDefault();
-        $.post('salvar_cliente.php', $(this).serialize(), function(resp) {
+        var id = $(this).find('input[name=id]').val();
+        var url = id ? 'atualizar_cliente.php' : 'salvar_cliente.php';
+        $.post(url, $(this).serialize(), function(resp) {
             if (resp.success) {
                 $('#clienteModal').modal('hide');
                 location.reload();
@@ -113,6 +117,85 @@ $(function() {
             e.preventDefault();
             e.stopImmediatePropagation();
         }
+    });
+
+    // Responsáveis
+    $(document).on('click', '#btnNovoResponsavel', function(){
+        $('#formResponsavel')[0].reset();
+        $('#formResponsavel input[name=id]').val('');
+        $('#responsavelModal .modal-title').text('Cadastrar Responsável');
+        $('#listaResponsavelModal').modal('hide');
+        $('#responsavelModal').modal('show');
+    });
+
+    $(document).on('click', '.btn-editar-resp', function(){
+        var tr = $(this).closest('tr');
+        $('#formResponsavel input[name=id]').val(tr.data('id'));
+        $('#formResponsavel input[name=nome]').val(tr.data('nome'));
+        $('#responsavelModal .modal-title').text('Editar Responsável');
+        $('#listaResponsavelModal').modal('hide');
+        $('#responsavelModal').modal('show');
+    });
+
+    $(document).on('click', '.btn-excluir-resp', function(){
+        var tr = $(this).closest('tr');
+        var id = tr.data('id');
+        var nome = tr.data('nome');
+        Swal.fire({
+            title: 'Excluir "'+nome+'"?',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonText: 'Sim',
+            cancelButtonText: 'Não'
+        }).then(function(res){
+            if(res.isConfirmed){
+                $.post('excluir_responsavel.php', {id:id}, function(resp){
+                    if(resp.success){
+                        location.reload();
+                    }
+                }, 'json');
+            }
+        });
+    });
+
+    // Clientes
+    $(document).on('click', '#btnNovoCliente', function(){
+        $('#formCliente')[0].reset();
+        $('#formCliente input[name=id]').val('');
+        $('#clienteModal .modal-title').text('Cadastrar Cliente');
+        $('#listaClienteModal').modal('hide');
+        $('#clienteModal').modal('show');
+    });
+
+    $(document).on('click', '.btn-editar-cliente', function(){
+        var tr = $(this).closest('tr');
+        $('#formCliente input[name=id]').val(tr.data('id'));
+        $('#formCliente input[name=cnpj]').val(tr.data('cnpj'));
+        $('#formCliente input[name=nome]').val(tr.data('nome'));
+        $('#clienteModal .modal-title').text('Editar Cliente');
+        $('#listaClienteModal').modal('hide');
+        $('#clienteModal').modal('show');
+    });
+
+    $(document).on('click', '.btn-excluir-cliente', function(){
+        var tr = $(this).closest('tr');
+        var id = tr.data('id');
+        var nome = tr.data('nome');
+        Swal.fire({
+            title: 'Excluir "'+nome+'"?',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonText: 'Sim',
+            cancelButtonText: 'Não'
+        }).then(function(res){
+            if(res.isConfirmed){
+                $.post('excluir_cliente.php', {id:id}, function(resp){
+                    if(resp.success){
+                        location.reload();
+                    }
+                }, 'json');
+            }
+        });
     });
 
     if(typeof clientesData !== 'undefined'){

--- a/atualizar_cliente.php
+++ b/atualizar_cliente.php
@@ -1,0 +1,24 @@
+<?php
+require 'config.php';
+
+$id = $_POST['id'] ?? 0;
+$cnpj = trim($_POST['cnpj'] ?? '');
+$nome = trim($_POST['nome'] ?? '');
+
+if (!$id || $cnpj === '' || $nome === '') {
+    echo json_encode(['success' => false, 'message' => 'Dados inválidos.']);
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT COUNT(*) FROM clientes WHERE cnpj = ? AND id != ?');
+$stmt->execute([$cnpj, $id]);
+if ($stmt->fetchColumn() > 0) {
+    echo json_encode(['success' => false, 'message' => 'CNPJ já cadastrado.']);
+    exit;
+}
+
+$stmt = $pdo->prepare('UPDATE clientes SET cnpj = ?, nome = ? WHERE id = ?');
+$stmt->execute([$cnpj, $nome, $id]);
+
+echo json_encode(['success' => true]);
+?>

--- a/atualizar_responsavel.php
+++ b/atualizar_responsavel.php
@@ -1,0 +1,23 @@
+<?php
+require 'config.php';
+
+$id = $_POST['id'] ?? 0;
+$nome = trim($_POST['nome'] ?? '');
+
+if (!$id || $nome === '') {
+    echo json_encode(['success' => false, 'message' => 'Dados inválidos.']);
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT COUNT(*) FROM responsaveis WHERE nome = ? AND id != ?');
+$stmt->execute([$nome, $id]);
+if ($stmt->fetchColumn() > 0) {
+    echo json_encode(['success' => false, 'message' => 'Responsável já cadastrado.']);
+    exit;
+}
+
+$stmt = $pdo->prepare('UPDATE responsaveis SET nome = ? WHERE id = ?');
+$stmt->execute([$nome, $id]);
+
+echo json_encode(['success' => true]);
+?>

--- a/excluir_cliente.php
+++ b/excluir_cliente.php
@@ -1,0 +1,13 @@
+<?php
+require 'config.php';
+
+$id = $_POST['id'] ?? 0;
+
+if ($id) {
+    $pdo->prepare('UPDATE tarefas SET cliente_id = NULL WHERE cliente_id = ?')->execute([$id]);
+    $pdo->prepare('DELETE FROM clientes WHERE id = ?')->execute([$id]);
+    echo json_encode(['success' => true]);
+} else {
+    echo json_encode(['success' => false]);
+}
+?>

--- a/excluir_responsavel.php
+++ b/excluir_responsavel.php
@@ -1,0 +1,13 @@
+<?php
+require 'config.php';
+
+$id = $_POST['id'] ?? 0;
+
+if ($id) {
+    $pdo->prepare('UPDATE tarefas SET responsavel_id = NULL WHERE responsavel_id = ?')->execute([$id]);
+    $pdo->prepare('DELETE FROM responsaveis WHERE id = ?')->execute([$id]);
+    echo json_encode(['success' => true]);
+} else {
+    echo json_encode(['success' => false]);
+}
+?>

--- a/index.php
+++ b/index.php
@@ -143,8 +143,75 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body text-center">
-        <button class="btn btn-primary me-2" data-bs-target="#responsavelModal" data-bs-toggle="modal" data-bs-dismiss="modal">Responsável</button>
-        <button class="btn btn-primary" data-bs-target="#clienteModal" data-bs-toggle="modal" data-bs-dismiss="modal">Cliente</button>
+        <button class="btn btn-primary me-2" data-bs-target="#listaResponsavelModal" data-bs-toggle="modal" data-bs-dismiss="modal">Responsável</button>
+        <button class="btn btn-primary" data-bs-target="#listaClienteModal" data-bs-toggle="modal" data-bs-dismiss="modal">Cliente</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Lista Responsáveis -->
+<div class="modal fade" id="listaResponsavelModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Responsáveis</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="d-flex justify-content-end mb-2">
+          <button class="btn btn-primary" id="btnNovoResponsavel">Novo</button>
+        </div>
+        <table class="table table-striped">
+          <thead>
+            <tr><th>Nome</th><th>Ação</th></tr>
+          </thead>
+          <tbody>
+            <?php foreach ($responsaveis as $r): ?>
+            <tr data-id="<?= $r['id'] ?>" data-nome="<?= htmlspecialchars($r['nome']) ?>">
+              <td><?= htmlspecialchars($r['nome']) ?></td>
+              <td>
+                <button class="btn btn-sm btn-secondary btn-editar-resp">Editar</button>
+                <button class="btn btn-sm btn-danger btn-excluir-resp">Excluir</button>
+              </td>
+            </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Lista Clientes -->
+<div class="modal fade" id="listaClienteModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Clientes</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="d-flex justify-content-end mb-2">
+          <button class="btn btn-primary" id="btnNovoCliente">Novo</button>
+        </div>
+        <table class="table table-striped">
+          <thead>
+            <tr><th>CNPJ</th><th>Nome</th><th>Ação</th></tr>
+          </thead>
+          <tbody>
+            <?php foreach ($clientes as $c): ?>
+            <tr data-id="<?= $c['id'] ?>" data-cnpj="<?= htmlspecialchars($c['cnpj']) ?>" data-nome="<?= htmlspecialchars($c['nome']) ?>">
+              <td><?= htmlspecialchars($c['cnpj']) ?></td>
+              <td><?= htmlspecialchars($c['nome']) ?></td>
+              <td>
+                <button class="btn btn-sm btn-secondary btn-editar-cliente">Editar</button>
+                <button class="btn btn-sm btn-danger btn-excluir-cliente">Excluir</button>
+              </td>
+            </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
       </div>
     </div>
   </div>
@@ -160,6 +227,7 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
       </div>
       <div class="modal-body">
         <div id="respAlert"></div>
+        <input type="hidden" name="id">
         <div class="mb-3">
           <label class="form-label">Nome</label>
           <input type="text" class="form-control" name="nome" required>
@@ -183,6 +251,7 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
       </div>
       <div class="modal-body">
         <div id="cliAlert"></div>
+        <input type="hidden" name="id">
         <div class="mb-3">
           <label class="form-label">CNPJ</label>
           <input type="text" class="form-control" name="cnpj" required>


### PR DESCRIPTION
## Resumo
- permite cadastrar, editar e excluir responsáveis e clientes
- adiciona modais de listagem com botão "Novo"
- cria rotas PHP para atualizar e remover registros
- ajusta JavaScript para lidar com ações de edição e exclusão

## Testes
- `php` não disponível para executar testes ou lint


------
https://chatgpt.com/codex/tasks/task_e_684c1b2eab1883258c557f8b407c6be7