### PR TITLE
Adiciona busca e paginacao em clientes

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -215,4 +215,54 @@ $(function() {
             $('#cliente_id').val(id);
         });
     }
+
+    // Filtro e paginação da lista de clientes
+    var tamPagina = 5;
+    var paginaAtual = 1;
+
+    function atualizarPaginacao(){
+        var linhas = $('#listaClienteModal tbody tr:visible');
+        var totalPaginas = Math.ceil(linhas.length / tamPagina) || 1;
+        if(paginaAtual > totalPaginas){ paginaAtual = totalPaginas; }
+        linhas.hide();
+        linhas.slice((paginaAtual-1)*tamPagina, paginaAtual*tamPagina).show();
+        $('#paginaAtual').text(paginaAtual + '/' + totalPaginas);
+        $('#btnPrevCliente').prop('disabled', paginaAtual === 1);
+        $('#btnNextCliente').prop('disabled', paginaAtual === totalPaginas);
+    }
+
+    $('#clienteBusca').on('keyup', function(){
+        var termo = $(this).val().toLowerCase();
+        $('#listaClienteModal tbody tr').each(function(){
+            var cnpj = $(this).data('cnpj').toLowerCase();
+            var nome = $(this).data('nome').toLowerCase();
+            $(this).toggle(cnpj.indexOf(termo) !== -1 || nome.indexOf(termo) !== -1);
+        });
+        paginaAtual = 1;
+        atualizarPaginacao();
+    });
+
+    $('#btnPrevCliente').on('click', function(e){
+        e.preventDefault();
+        if(paginaAtual > 1){
+            paginaAtual--;
+            atualizarPaginacao();
+        }
+    });
+
+    $('#btnNextCliente').on('click', function(e){
+        e.preventDefault();
+        var totalPaginas = Math.ceil($('#listaClienteModal tbody tr:visible').length / tamPagina) || 1;
+        if(paginaAtual < totalPaginas){
+            paginaAtual++;
+            atualizarPaginacao();
+        }
+    });
+
+    $('#listaClienteModal').on('shown.bs.modal', function(){
+        paginaAtual = 1;
+        $('#clienteBusca').val('');
+        $('#listaClienteModal tbody tr').show();
+        atualizarPaginacao();
+    });
 });

--- a/index.php
+++ b/index.php
@@ -194,6 +194,7 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
       </div>
       <div class="modal-body">
         <div class="d-flex justify-content-end mb-2">
+          <input type="text" class="form-control w-50 me-2" id="clienteBusca" placeholder="Filtrar...">
           <button class="btn btn-primary" id="btnNovoCliente">Novo</button>
         </div>
         <table class="table table-striped">
@@ -213,6 +214,13 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
             <?php endforeach; ?>
           </tbody>
         </table>
+        <nav>
+          <ul class="pagination justify-content-center" id="paginacaoClientes">
+            <li class="page-item"><a href="#" class="page-link" id="btnPrevCliente">Anterior</a></li>
+            <li class="page-item disabled"><span class="page-link" id="paginaAtual">1/1</span></li>
+            <li class="page-item"><a href="#" class="page-link" id="btnNextCliente">Próxima</a></li>
+          </ul>
+        </nav>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add search input next to *Novo* button in client list
- implement pagination for client table
- update JS to filter and paginate client rows

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c24c05e0c8325be17c73fdc6d93a8