### PR TITLE
Implementa limite de caracteres nos cards do kanban

### DIFF
--- a/index.php
+++ b/index.php
@@ -64,11 +64,15 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
                         $tempo = 'Muito atrasada';
                         $badge = 'danger';
                     }
+
+                    $detalhesPreview = mb_strlen($tarefa['detalhes']) > 200
+                        ? mb_substr($tarefa['detalhes'], 0, 200) . '...'
+                        : $tarefa['detalhes'];
                 ?>
                 <div class="card mb-2 tarefa-card" data-id="<?= $tarefa['id'] ?>" data-bs-toggle="modal" data-bs-target="#detalhesModal" onclick="carregarDetalhes(<?= $tarefa['id'] ?>)">
                     <div class="card-body p-2">
                         <h6 class="card-title mb-1"><?= htmlspecialchars($tarefa['titulo']) ?></h6>
-                        <p class="mb-1 small"><?= htmlspecialchars($tarefa['detalhes']) ?></p>
+                        <p class="mb-1 small"><?= htmlspecialchars($detalhesPreview) ?></p>
                         <p class="mb-0"><span class="badge bg-secondary">Responsável: <?= htmlspecialchars($tarefa['responsavel'] ?? 'N/A') ?></span></p>
                         <p class="mb-0 mt-1"><span class="badge bg-<?= $badge ?>"><?= $tempo ?></span></p>
                     </div>


### PR DESCRIPTION
## Resumo
- exibe somente os primeiros 200 caracteres dos detalhes na visualização do kanban

## Testes
- `php -l index.php` *(falhou: php não está instalado)*

------
https://chatgpt.com/codex/tasks/task_e_684c32fc7f9483258a299b22345f334a