### PR TITLE
Implementa status finalizado

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,6 @@ As cores principais do layout são `#131f45` e branco, garantindo boa visualiza�
 
 ### Favicon
 O arquivo `favicon.ico` já está incluído na raiz do projeto. A página `index.php` referencia esse ícone no elemento `<head>` para exibição pelo navegador. Caso deseje personalizar o ícone, substitua o arquivo `favicon.ico` por outro de sua escolha e recarregue a aplicação.
+
+### Status Finalizado
+Quando a situação de uma tarefa é alterada para **Finalizado**, o indicador de prazo deixa de ser calculado e passa a mostrar o texto **Finalizado**.

--- a/index.php
+++ b/index.php
@@ -47,22 +47,27 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
             <div class="tarefa-col" data-status="<?= htmlspecialchars($status) ?>">
             <?php foreach ($tarefas[$status] as $tarefa): ?>
                 <?php
-                    $diff = (new DateTime($tarefa['created_at']))->diff(new DateTime())->days;
-                    if ($diff == 0) {
-                        $tempo = 'Normal';
-                        $badge = 'success';
-                    } elseif ($diff == 1) {
-                        $tempo = 'Atrasada';
-                        $badge = 'warning';
-                    } elseif ($diff == 2) {
-                        $tempo = 'Muito atrasada';
-                        $badge = 'danger';
-                    } elseif ($diff > 5) {
-                        $tempo = 'Urgente muito atrasada';
-                        $badge = 'dark';
-                      } else {
-                        $tempo = 'Muito atrasada';
-                        $badge = 'danger';
+                    if ($tarefa['status'] === 'Finalizado') {
+                        $tempo = 'Finalizado';
+                        $badge = 'primary';
+                    } else {
+                        $diff = (new DateTime($tarefa['created_at']))->diff(new DateTime())->days;
+                        if ($diff == 0) {
+                            $tempo = 'Normal';
+                            $badge = 'success';
+                        } elseif ($diff == 1) {
+                            $tempo = 'Atrasada';
+                            $badge = 'warning';
+                        } elseif ($diff == 2) {
+                            $tempo = 'Muito atrasada';
+                            $badge = 'danger';
+                        } elseif ($diff > 5) {
+                            $tempo = 'Urgente muito atrasada';
+                            $badge = 'dark';
+                        } else {
+                            $tempo = 'Muito atrasada';
+                            $badge = 'danger';
+                        }
                     }
 
                     $detalhesPreview = mb_strlen($tarefa['detalhes']) > 200


### PR DESCRIPTION
## Summary
- evita contagem de dias para tarefas finalizadas
- documenta novo comportamento no README

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684edc6388248325a1cd8224b997881f