### PR TITLE
Corrige coluna status na consulta de tarefas

### DIFF
--- a/index.php
+++ b/index.php
@@ -3,9 +3,15 @@ require 'config.php';
 
 // Busca tarefas do banco de dados
 function obterTarefasPorStatus($pdo, $status) {
-  $stmt = $pdo->prepare("SELECT t.id, t.titulo, t.detalhes, t.created_at, r.nome AS responsavel FROM tarefas t LEFT JOIN responsaveis r ON t.responsavel_id = r.id WHERE status = ? ORDER BY t.id DESC");
-  $stmt->execute([$status]);
-  return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $stmt = $pdo->prepare(
+        "SELECT t.id, t.titulo, t.detalhes, t.created_at, t.status, " .
+        "r.nome AS responsavel " .
+        "FROM tarefas t " .
+        "LEFT JOIN responsaveis r ON t.responsavel_id = r.id " .
+        "WHERE t.status = ? ORDER BY t.id DESC"
+    );
+    $stmt->execute([$status]);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
 $statuses = ['A fazer', 'Fazendo', 'Agendado', 'Aguardando', 'Finalizado'];


### PR DESCRIPTION
## Resumo
- include a coluna `status` ao consultar tarefas para evitar erro de chave indefinida

## Testes
- `php -l index.php` *(falhou: comando php não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_684ede85a058832593049902ed7d63fa