### PR TITLE
Corrige quebra de texto do cliente no Kanban

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -17,3 +17,9 @@ body {
 .tarefa-col {
     min-height: 70px;
 }
+
+/* Permite que o nome do cliente quebre linha dentro do badge */
+.badge-cliente {
+    white-space: normal;
+    word-break: break-word;
+}

--- a/index.php
+++ b/index.php
@@ -118,7 +118,7 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
                     <div class="card-body p-2">
                         <h6 class="card-title mb-1"><?= htmlspecialchars($tarefa['titulo']) ?></h6>
                         <p class="mb-1 small"><?= htmlspecialchars($detalhesPreview) ?></p>
-                        <p class="mb-0"><span class="badge bg-info text-dark">Cliente: <?= htmlspecialchars($tarefa['cliente'] ?? 'N/A') ?></span></p>
+                        <p class="mb-0"><span class="badge bg-info text-dark badge-cliente">Cliente: <?= htmlspecialchars($tarefa['cliente'] ?? 'N/A') ?></span></p>
                         <p class="mb-0"><span class="badge bg-secondary">Responsável: <?= htmlspecialchars($tarefa['responsavel'] ?? 'N/A') ?></span></p>
                         <p class="mb-0 mt-1"><span class="badge bg-<?= $badge ?>"><?= $tempo ?></span></p>
                     </div>


### PR DESCRIPTION
## Resumo
- permite que o badge do cliente quebre linha no card do Kanban

## Testes
- `php -l index.php` *(falhou: `php` não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6855dc9f64748325a911c05e93b27b7a