### PR TITLE
Adicionar campo tipo de atendimento

### DIFF
--- a/atualizar_tarefa.php
+++ b/atualizar_tarefa.php
@@ -5,11 +5,12 @@ $id = $_POST['id'] ?? 0;
 $detalhes = $_POST['detalhes'] ?? '';
 $responsavel_id = $_POST['responsavel_id'] ?: null;
 $cliente_id = $_POST['cliente_id'] ?: null;
+$tipo_atendimento = $_POST['tipo_atendimento'] ?? 'Remoto';
 
 if ($id) {
     $now = date('Y-m-d H:i:s');
-    $stmt = $pdo->prepare('UPDATE tarefas SET detalhes = ?, responsavel_id = ?, cliente_id = ?, updated_at = ? WHERE id = ?');
-    $stmt->execute([$detalhes, $responsavel_id, $cliente_id, $now, $id]);
+    $stmt = $pdo->prepare('UPDATE tarefas SET detalhes = ?, responsavel_id = ?, cliente_id = ?, tipo_atendimento = ?, updated_at = ? WHERE id = ?');
+    $stmt->execute([$detalhes, $responsavel_id, $cliente_id, $tipo_atendimento, $now, $id]);
     echo json_encode(['success' => true]);
 } else {
     echo json_encode(['success' => false]);

--- a/detalhes_tarefa.php
+++ b/detalhes_tarefa.php
@@ -73,6 +73,13 @@ $comentarios = $com->fetchAll(PDO::FETCH_ASSOC);
         </ul>
       </div>
     </div>
+    <div class="mb-3">
+      <label class="form-label">Tipo de atendimento</label>
+      <select class="form-select" name="tipo_atendimento">
+        <option value="Remoto" <?= $tarefa['tipo_atendimento'] == 'Remoto' ? 'selected' : '' ?>>Remoto</option>
+        <option value="Presencial" <?= $tarefa['tipo_atendimento'] == 'Presencial' ? 'selected' : '' ?>>Presencial</option>
+      </select>
+    </div>
     <button type="submit" class="btn btn-primary mb-3">Salvar Alterações</button>
   </form>
 

--- a/index.php
+++ b/index.php
@@ -11,7 +11,7 @@ function obterTarefasPorStatus(
   $modificacaoAte = null
 ) {
   $sql =
-      "SELECT t.id, t.titulo, t.detalhes, t.created_at, t.status, " .
+      "SELECT t.id, t.titulo, t.detalhes, t.created_at, t.status, t.tipo_atendimento, " .
       "r.nome AS responsavel, c.nome AS cliente " .
       "FROM tarefas t " .
       "LEFT JOIN responsaveis r ON t.responsavel_id = r.id " .
@@ -203,6 +203,13 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
               <?php endforeach; ?>
             </ul>
           </div>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Tipo de atendimento</label>
+          <select class="form-select" name="tipo_atendimento">
+            <option value="Remoto">Remoto</option>
+            <option value="Presencial">Presencial</option>
+          </select>
         </div>
         <div class="mb-3">
           <label class="form-label">Data e Hora de Criação</label>

--- a/init_db.php
+++ b/init_db.php
@@ -18,6 +18,7 @@ $queries = [
         detalhes TEXT,
         responsavel_id INTEGER,
         cliente_id INTEGER,
+        tipo_atendimento TEXT DEFAULT 'Remoto',
         status TEXT NOT NULL DEFAULT 'A fazer',
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
         updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
@@ -38,6 +39,12 @@ $queries = [
 
 foreach ($queries as $query) {
     $pdo->exec($query);
+}
+
+// Adiciona coluna tipo_atendimento se não existir
+$cols = $pdo->query("PRAGMA table_info(tarefas)")->fetchAll(PDO::FETCH_COLUMN, 1);
+if (!in_array('tipo_atendimento', $cols)) {
+    $pdo->exec("ALTER TABLE tarefas ADD COLUMN tipo_atendimento TEXT DEFAULT 'Remoto'");
 }
 
 echo "Banco de dados inicializado com sucesso.\n";

--- a/salvar_tarefa.php
+++ b/salvar_tarefa.php
@@ -5,6 +5,7 @@ $titulo = $_POST['titulo'] ?? '';
 $detalhes = $_POST['detalhes'] ?? '';
 $responsavel_id = $_POST['responsavel_id'] ?: null;
 $cliente_id = $_POST['cliente_id'] ?: null;
+$tipo_atendimento = $_POST['tipo_atendimento'] ?? 'Remoto';
 $created_at = $_POST['created_at'] ?? date('Y-m-d H:i:s');
 
 if ($created_at) {
@@ -13,8 +14,8 @@ if ($created_at) {
 $updated_at = $created_at;
 
 if ($titulo) {
-    $stmt = $pdo->prepare('INSERT INTO tarefas (titulo, detalhes, responsavel_id, cliente_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)');
-    $stmt->execute([$titulo, $detalhes, $responsavel_id, $cliente_id, 'A fazer', $created_at, $updated_at]);
+    $stmt = $pdo->prepare('INSERT INTO tarefas (titulo, detalhes, responsavel_id, cliente_id, tipo_atendimento, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
+    $stmt->execute([$titulo, $detalhes, $responsavel_id, $cliente_id, $tipo_atendimento, 'A fazer', $created_at, $updated_at]);
 }
 
 header('Location: index.php');


### PR DESCRIPTION
## Summary
- adicionar coluna `tipo_atendimento` no banco e script de inicialização
- permitir definir o tipo de atendimento ao criar tarefa
- permitir editar o tipo de atendimento nos detalhes da tarefa

## Testing
- `php -l init_db.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68631644dacc8325b15c0bf17af5258a