### PR TITLE
Implementa botões de ação nos cards

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -23,3 +23,13 @@ body {
     white-space: normal;
     word-break: break-word;
 }
+
+/* Botoes de acao nos cards */
+.tarefa-card {
+    position: relative;
+}
+.tarefa-card .card-actions {
+    position: absolute;
+    bottom: 0.25rem;
+    right: 0.25rem;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -119,6 +119,29 @@ $(function() {
         }
     });
 
+    // Botoes de acao nos cards
+    $(document).on('click', '.btn-duplicar', function(e){
+        e.preventDefault();
+        e.stopPropagation();
+        var id = $(this).closest('.tarefa-card').data('id');
+        $.post('duplicar_tarefa.php', {id: id}, function(resp){
+            if(resp.success){
+                location.reload();
+            }
+        }, 'json');
+    });
+
+    $(document).on('click', '.btn-finalizar', function(e){
+        e.preventDefault();
+        e.stopPropagation();
+        var id = $(this).closest('.tarefa-card').data('id');
+        $.post('atualizar_status.php', {id: id, status: 'Finalizado'}, function(resp){
+            if(resp.success){
+                location.reload();
+            }
+        }, 'json');
+    });
+
     // Responsáveis
     $(document).on('click', '#btnNovoResponsavel', function(){
         $('#formResponsavel')[0].reset();

--- a/duplicar_tarefa.php
+++ b/duplicar_tarefa.php
@@ -1,0 +1,35 @@
+<?php
+require 'config.php';
+
+$id = $_POST['id'] ?? 0;
+
+if (!$id) {
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT titulo, detalhes, responsavel_id, cliente_id, tipo_atendimento, status FROM tarefas WHERE id = ?');
+$stmt->execute([$id]);
+$tarefa = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$tarefa) {
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$now = date('Y-m-d H:i:s');
+
+$stmt = $pdo->prepare('INSERT INTO tarefas (titulo, detalhes, responsavel_id, cliente_id, tipo_atendimento, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
+$stmt->execute([
+    $tarefa['titulo'],
+    $tarefa['detalhes'],
+    $tarefa['responsavel_id'],
+    $tarefa['cliente_id'],
+    $tarefa['tipo_atendimento'],
+    $tarefa['status'],
+    $now,
+    $now
+]);
+
+echo json_encode(['success' => true]);
+?>

--- a/index.php
+++ b/index.php
@@ -70,6 +70,7 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="assets/css/style.css">
     <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>
@@ -147,12 +148,16 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
                         : $tarefa['detalhes'];
                 ?>
                 <div class="card mb-2 tarefa-card" data-id="<?= $tarefa['id'] ?>" data-bs-toggle="modal" data-bs-target="#detalhesModal" onclick="carregarDetalhes(<?= $tarefa['id'] ?>)">
-                    <div class="card-body p-2">
+                    <div class="card-body p-2 pb-4">
                         <h6 class="card-title mb-1"><?= htmlspecialchars($tarefa['titulo']) ?></h6>
                         <p class="mb-1 small"><?= htmlspecialchars($detalhesPreview) ?></p>
                         <p class="mb-0"><span class="badge bg-info text-dark badge-cliente">Cliente: <?= htmlspecialchars($tarefa['cliente'] ?? 'N/A') ?></span></p>
                         <p class="mb-0"><span class="badge bg-secondary">Responsável: <?= htmlspecialchars($tarefa['responsavel'] ?? 'N/A') ?></span></p>
                         <p class="mb-0 mt-1"><span class="badge bg-<?= $badge ?>"><?= $tempo ?></span></p>
+                        <div class="card-actions d-flex gap-1">
+                            <button class="btn btn-light btn-sm btn-duplicar" title="Duplicar"><i class="bi bi-files"></i></button>
+                            <button class="btn btn-light btn-sm btn-finalizar" title="Finalizar"><i class="bi bi-check-circle"></i></button>
+                        </div>
                     </div>
                 </div>
             <?php endforeach; ?>


### PR DESCRIPTION
## Resumo
- adiciona link para Bootstrap Icons
- inclui botões de duplicar e finalizar nos cards do kanban
- cria CSS para posicionar os botões
- implementa lógica JS para duplicar e finalizar tarefas via AJAX
- cria endpoint `duplicar_tarefa.php`

## Testes
- `php -l index.php` *(falhou: comando php indisponível)*
- `php -l duplicar_tarefa.php` *(falhou: comando php indisponível)*

------
https://chatgpt.com/codex/tasks/task_e_686571c9ee008325b36aa789bf69d429