### PR TITLE
Implementa arquivamento de tarefas

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,6 @@ O arquivo `favicon.ico` já está incluído na raiz do projeto. A página `index
 
 ### Status Finalizado
 Quando a situação de uma tarefa é alterada para **Finalizado**, o indicador de prazo deixa de ser calculado e passa a mostrar o texto **Finalizado**.
+
+### Arquivar tarefas
+Tarefas finalizadas podem ser arquivadas clicando no ícone de arquivo no card. Arquivadas não aparecem no kanban e ficam listadas no botão **Arquivadas** no topo da página.

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -142,6 +142,17 @@ $(function() {
         }, 'json');
     });
 
+    $(document).on('click', '.btn-arquivar', function(e){
+        e.preventDefault();
+        e.stopPropagation();
+        var id = $(this).closest('.tarefa-card').data('id');
+        $.post('atualizar_status.php', {id: id, status: 'Arquivada'}, function(resp){
+            if(resp.success){
+                location.reload();
+            }
+        }, 'json');
+    });
+
     // Responsáveis
     $(document).on('click', '#btnNovoResponsavel', function(){
         $('#formResponsavel')[0].reset();

--- a/index.php
+++ b/index.php
@@ -57,6 +57,7 @@ foreach ($statuses as $s) {
       $dataModificacaoAte
   );
 }
+$arquivadas = obterTarefasPorStatus($pdo, 'Arquivada');
 
 $responsaveis = $pdo->query('SELECT id, nome FROM responsaveis')->fetchAll(PDO::FETCH_ASSOC);
 $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FETCH_ASSOC);
@@ -80,7 +81,7 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
         <div class="d-flex">
             <button class="btn btn-light me-2" data-bs-toggle="modal" data-bs-target="#novaTarefaModal">Nova Tarefa</button>
             <button class="btn btn-light me-2" data-bs-toggle="modal" data-bs-target="#cadastroModal">Cadastro</button>
-            <button class="btn btn-light">Configurações</button>
+            <button class="btn btn-light" data-bs-toggle="modal" data-bs-target="#arquivadasModal">Arquivadas</button>
         </div>
     </div>
     </nav>
@@ -155,8 +156,13 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
                         <p class="mb-0"><span class="badge bg-secondary">Responsável: <?= htmlspecialchars($tarefa['responsavel'] ?? 'N/A') ?></span></p>
                         <p class="mb-0 mt-1"><span class="badge bg-<?= $badge ?>"><?= $tempo ?></span></p>
                         <div class="card-actions d-flex gap-1">
+                            <?php if ($tarefa['status'] === 'Finalizado'): ?>
+                                <button class="btn btn-light btn-sm btn-arquivar" title="Arquivar"><i class="bi bi-archive"></i></button>
+                            <?php endif; ?>
                             <button class="btn btn-light btn-sm btn-duplicar" title="Duplicar"><i class="bi bi-files"></i></button>
-                            <button class="btn btn-light btn-sm btn-finalizar" title="Finalizar"><i class="bi bi-check-circle"></i></button>
+                            <?php if ($tarefa['status'] !== 'Finalizado'): ?>
+                                <button class="btn btn-light btn-sm btn-finalizar" title="Finalizar"><i class="bi bi-check-circle"></i></button>
+                            <?php endif; ?>
                         </div>
                     </div>
                 </div>
@@ -315,6 +321,32 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
             <li class="page-item"><a href="#" class="page-link" id="btnNextCliente">Próxima</a></li>
           </ul>
         </nav>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Modal Arquivadas -->
+<div class="modal fade" id="arquivadasModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Tarefas Arquivadas</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <?php if ($arquivadas): ?>
+          <ul class="list-group">
+            <?php foreach ($arquivadas as $a): ?>
+              <li class="list-group-item d-flex justify-content-between">
+                <?= htmlspecialchars($a['titulo']) ?>
+                <small class="text-muted"><?= date('d/m/Y', strtotime($a['created_at'])) ?></small>
+              </li>
+            <?php endforeach; ?>
+          </ul>
+        <?php else: ?>
+          <p>Nenhuma tarefa arquivada.</p>
+        <?php endif; ?>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Resumo
- acrescenta opção de arquivar tarefas finalizadas
- lista de arquivadas acessível pelo botão superior
- oculta o botão de finalizar quando a tarefa já está finalizada
- inclui documentação sobre o novo recurso

## Testes
- `php -l index.php` *(falhou: php não disponível)*

------
https://chatgpt.com/codex/tasks/task_e_6867d5b7021c83259109c8123bbe4f33