### PR TITLE
Atualização automática do kanban

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -7,7 +7,30 @@ function carregarDetalhes(id) {
     });
 }
 
+function atualizarKanban(callback){
+    var dados = '';
+    if($('#filtrosForm').length){
+        dados = $('#filtrosForm').serialize();
+    }
+    $.get('obter_tarefas.php', dados, function(resp){
+        for(var status in resp){
+            $('.tarefa-col[data-status="'+status+'"]').html(resp[status]);
+        }
+        if(typeof callback === 'function') callback();
+    }, 'json');
+}
+
 $(function() {
+    setInterval(atualizarKanban, 5000);
+
+    $('#novaTarefaForm').on('submit', function(e){
+        e.preventDefault();
+        $.post('salvar_tarefa.php', $(this).serialize(), function(){
+            $('#novaTarefaModal').modal('hide');
+            atualizarKanban();
+        }, 'json');
+    });
+
     $('#formResponsavel').on('submit', function(e) {
         e.preventDefault();
         var id = $(this).find('input[name=id]').val();
@@ -15,7 +38,7 @@ $(function() {
         $.post(url, $(this).serialize(), function(resp) {
             if (resp.success) {
                 $('#responsavelModal').modal('hide');
-                location.reload();
+                atualizarKanban();
             } else {
                 $('#respAlert').html('<div class="alert alert-warning alert-dismissible fade show" role="alert">'+resp.message+'<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>');
             }
@@ -29,7 +52,7 @@ $(function() {
         $.post(url, $(this).serialize(), function(resp) {
             if (resp.success) {
                 $('#clienteModal').modal('hide');
-                location.reload();
+                atualizarKanban();
             } else {
                 $('#cliAlert').html('<div class="alert alert-warning alert-dismissible fade show" role="alert">'+resp.message+'<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>');
             }
@@ -42,7 +65,7 @@ $(function() {
         $.post('atualizar_status.php', $(this).serialize(), function(resp) {
             if (resp.success) {
                 $('#detalhesModal').modal('hide');
-                location.reload();
+                atualizarKanban();
             }
         }, 'json');
     });
@@ -53,7 +76,7 @@ $(function() {
         $.post('atualizar_tarefa.php', $(this).serialize(), function(resp){
             if(resp.success){
                 $('#detalhesModal').modal('hide');
-                location.reload();
+                atualizarKanban();
             }
         }, 'json');
     });
@@ -84,7 +107,7 @@ $(function() {
                 $.post('excluir_tarefa.php', {id:id}, function(resp){
                     if(resp.success){
                         $('#detalhesModal').modal('hide');
-                        location.reload();
+                        atualizarKanban();
                     }
                 }, 'json');
             }
@@ -126,7 +149,7 @@ $(function() {
         var id = $(this).closest('.tarefa-card').data('id');
         $.post('duplicar_tarefa.php', {id: id}, function(resp){
             if(resp.success){
-                location.reload();
+                atualizarKanban();
             }
         }, 'json');
     });
@@ -137,7 +160,7 @@ $(function() {
         var id = $(this).closest('.tarefa-card').data('id');
         $.post('atualizar_status.php', {id: id, status: 'Finalizado'}, function(resp){
             if(resp.success){
-                location.reload();
+                atualizarKanban();
             }
         }, 'json');
     });
@@ -148,7 +171,7 @@ $(function() {
         var id = $(this).closest('.tarefa-card').data('id');
         $.post('atualizar_status.php', {id: id, status: 'Arquivada'}, function(resp){
             if(resp.success){
-                location.reload();
+                atualizarKanban();
             }
         }, 'json');
     });
@@ -185,7 +208,7 @@ $(function() {
             if(res.isConfirmed){
                 $.post('excluir_responsavel.php', {id:id}, function(resp){
                     if(resp.success){
-                        location.reload();
+                        atualizarKanban();
                     }
                 }, 'json');
             }
@@ -225,7 +248,7 @@ $(function() {
             if(res.isConfirmed){
                 $.post('excluir_cliente.php', {id:id}, function(resp){
                     if(resp.success){
-                        location.reload();
+                        atualizarKanban();
                     }
                 }, 'json');
             }

--- a/index.php
+++ b/index.php
@@ -88,7 +88,7 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
 <div class="container-fluid mt-4">
     <div class="row mb-3">
         <div class="col">
-            <form class="row gy-2 gx-2 align-items-end" method="GET" action="index.php">
+            <form id="filtrosForm" class="row gy-2 gx-2 align-items-end" method="GET" action="index.php">
             <div class="col-auto">
                     <label class="form-label" for="dataCadastroDe">Cadastro de</label>
                     <input type="date" id="dataCadastroDe" name="data_cadastro_de" class="form-control" value="<?= htmlspecialchars($dataCadastroDe ?? '') ?>">
@@ -176,7 +176,7 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
 <!-- Modal Nova Tarefa -->
 <div class="modal fade" id="novaTarefaModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
-    <form class="modal-content" method="POST" action="salvar_tarefa.php">
+    <form id="novaTarefaForm" class="modal-content" method="POST" action="salvar_tarefa.php">
       <div class="modal-header">
         <h5 class="modal-title">Nova Tarefa</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/obter_tarefas.php
+++ b/obter_tarefas.php
@@ -1,0 +1,103 @@
+<?php
+require 'config.php';
+
+function obterTarefasPorStatus($pdo, $status, $cadastroDe = null, $cadastroAte = null, $modificacaoDe = null, $modificacaoAte = null) {
+    $sql = "SELECT t.id, t.titulo, t.detalhes, t.created_at, t.status, t.tipo_atendimento, " .
+           "r.nome AS responsavel, c.nome AS cliente " .
+           "FROM tarefas t " .
+           "LEFT JOIN responsaveis r ON t.responsavel_id = r.id " .
+           "LEFT JOIN clientes c ON t.cliente_id = c.id " .
+           "WHERE t.status = ?";
+    $params = [$status];
+    if ($cadastroDe) {
+        $sql .= " AND date(t.created_at) >= ?";
+        $params[] = $cadastroDe;
+    }
+    if ($cadastroAte) {
+        $sql .= " AND date(t.created_at) <= ?";
+        $params[] = $cadastroAte;
+    }
+    if ($modificacaoDe) {
+        $sql .= " AND date(t.updated_at) >= ?";
+        $params[] = $modificacaoDe;
+    }
+    if ($modificacaoAte) {
+        $sql .= " AND date(t.updated_at) <= ?";
+        $params[] = $modificacaoAte;
+    }
+    $sql .= " ORDER BY t.id DESC";
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+$statuses = ['A fazer', 'Fazendo', 'Agendado', 'Aguardando', 'Finalizado'];
+$dataCadastroDe = $_GET['data_cadastro_de'] ?? null;
+$dataCadastroAte = $_GET['data_cadastro_ate'] ?? null;
+$dataModificacaoDe = $_GET['data_modificacao_de'] ?? null;
+$dataModificacaoAte = $_GET['data_modificacao_ate'] ?? null;
+
+$result = [];
+foreach ($statuses as $status) {
+    $tarefas = obterTarefasPorStatus(
+        $pdo,
+        $status,
+        $dataCadastroDe,
+        $dataCadastroAte,
+        $dataModificacaoDe,
+        $dataModificacaoAte
+    );
+
+    ob_start();
+    foreach ($tarefas as $tarefa) {
+        if ($tarefa['status'] === 'Finalizado') {
+            $tempo = 'Finalizado';
+            $badge = 'primary';
+        } else {
+            $diff = (new DateTime($tarefa['created_at']))->diff(new DateTime())->days;
+            if ($diff == 0) {
+                $tempo = 'Normal';
+                $badge = 'success';
+            } elseif ($diff == 1) {
+                $tempo = 'Atrasada';
+                $badge = 'warning';
+            } elseif ($diff == 2) {
+                $tempo = 'Muito atrasada';
+                $badge = 'danger';
+            } elseif ($diff > 5) {
+                $tempo = 'Urgente muito atrasada';
+                $badge = 'dark';
+            } else {
+                $tempo = 'Muito atrasada';
+                $badge = 'danger';
+            }
+        }
+        $detalhesPreview = mb_strlen($tarefa['detalhes']) > 200
+            ? mb_substr($tarefa['detalhes'], 0, 200) . '...'
+            : $tarefa['detalhes'];
+        ?>
+        <div class="card mb-2 tarefa-card" data-id="<?= $tarefa['id'] ?>" data-bs-toggle="modal" data-bs-target="#detalhesModal" onclick="carregarDetalhes(<?= $tarefa['id'] ?>)">
+            <div class="card-body p-2 pb-4">
+                <h6 class="card-title mb-1"><?= htmlspecialchars($tarefa['titulo']) ?></h6>
+                <p class="mb-1 small"><?= htmlspecialchars($detalhesPreview) ?></p>
+                <p class="mb-0"><span class="badge bg-info text-dark badge-cliente">Cliente: <?= htmlspecialchars($tarefa['cliente'] ?? 'N/A') ?></span></p>
+                <p class="mb-0"><span class="badge bg-secondary">Responsável: <?= htmlspecialchars($tarefa['responsavel'] ?? 'N/A') ?></span></p>
+                <p class="mb-0 mt-1"><span class="badge bg-<?= $badge ?>"><?= $tempo ?></span></p>
+                <div class="card-actions d-flex gap-1">
+                    <?php if ($tarefa['status'] === 'Finalizado'): ?>
+                        <button class="btn btn-light btn-sm btn-arquivar" title="Arquivar"><i class="bi bi-archive"></i></button>
+                    <?php endif; ?>
+                    <button class="btn btn-light btn-sm btn-duplicar" title="Duplicar"><i class="bi bi-files"></i></button>
+                    <?php if ($tarefa['status'] !== 'Finalizado'): ?>
+                        <button class="btn btn-light btn-sm btn-finalizar" title="Finalizar"><i class="bi bi-check-circle"></i></button>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+        <?php
+    }
+    $result[$status] = ob_get_clean();
+}
+
+header('Content-Type: application/json');
+echo json_encode($result);

--- a/salvar_tarefa.php
+++ b/salvar_tarefa.php
@@ -18,6 +18,12 @@ if ($titulo) {
     $stmt->execute([$titulo, $detalhes, $responsavel_id, $cliente_id, $tipo_atendimento, 'A fazer', $created_at, $updated_at]);
 }
 
+$isAjax = strtolower($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'xmlhttprequest';
+if ($isAjax) {
+    echo json_encode(['success' => true]);
+    exit;
+}
+
 header('Location: index.php');
 exit;
 ?>


### PR DESCRIPTION
## Summary
- add endpoint `obter_tarefas.php` que devolve os cartões do kanban em JSON
- suportar envio por AJAX em `salvar_tarefa.php`
- incluir ids nos formulários de filtro e de nova tarefa
- atualizar `app.js` para buscar periodicamente as tarefas e evitar recarregar a página

## Testing
- `php -l obter_tarefas.php` *(falhou: comando não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6867e06e03e08325861b7d70eae4430f