### PR TITLE
Corrige arquivamento sem abrir modal

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -168,6 +168,7 @@ $(function() {
     $(document).on('click', '.btn-arquivar', function(e){
         e.preventDefault();
         e.stopPropagation();
+        e.stopImmediatePropagation();
         var id = $(this).closest('.tarefa-card').data('id');
         $.post('atualizar_status.php', {id: id, status: 'Arquivada'}, function(resp){
             if(resp.success){


### PR DESCRIPTION
## Resumo
- impedir que o modal de detalhes seja aberto ao arquivar tarefas

## Testes
- `node --check assets/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6867e5844ccc8325bb35af08ec92f277