### PR TITLE
Fix archiving button

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -152,12 +152,19 @@ $(function() {
         }
     }).disableSelection();
 
-    // Impede abertura do modal quando o card está sendo arrastado
+    // Abre detalhes ao clicar no card, exceto durante arraste ou em botoes
     $(document).on('click', '.tarefa-card', function(e){
         if(isDragging){
             e.preventDefault();
             e.stopImmediatePropagation();
+            return;
         }
+        if($(e.target).closest('.card-actions').length){
+            return;
+        }
+        var id = $(this).data('id');
+        carregarDetalhes(id);
+        $('#detalhesModal').modal('show');
     });
 
     // Botoes de acao nos cards

--- a/index.php
+++ b/index.php
@@ -149,7 +149,7 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
                         ? mb_substr($tarefa['detalhes'], 0, 200) . '...'
                         : $tarefa['detalhes'];
                 ?>
-                <div class="card mb-2 tarefa-card position-relative" data-id="<?= $tarefa['id'] ?>" data-bs-toggle="modal" data-bs-target="#detalhesModal" onclick="carregarDetalhes(<?= $tarefa['id'] ?>)">
+                <div class="card mb-2 tarefa-card position-relative" data-id="<?= $tarefa['id'] ?>">
                     <div class="card-body p-2 pb-4">
                     <div class="position-absolute top-0 end-0 m-1 text-danger icon-notificacao">
                             <i class="bi bi-bell"></i>

--- a/obter_tarefas.php
+++ b/obter_tarefas.php
@@ -77,7 +77,7 @@ foreach ($statuses as $status) {
             ? mb_substr($tarefa['detalhes'], 0, 200) . '...'
             : $tarefa['detalhes'];
         ?>
-        <div class="card mb-2 tarefa-card position-relative" data-id="<?= $tarefa['id'] ?>" data-bs-toggle="modal" data-bs-target="#detalhesModal" onclick="carregarDetalhes(<?= $tarefa['id'] ?>)">
+        <div class="card mb-2 tarefa-card position-relative" data-id="<?= $tarefa['id'] ?>">
             <div class="card-body p-2 pb-4">
                 <div class="position-absolute top-0 end-0 m-1 text-danger icon-notificacao">
                     <i class="bi bi-bell"></i>


### PR DESCRIPTION
## Summary
- fix event propagation on the archive button
- remove inline modal triggers from kanban cards
- open task details only when clicking the card itself

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f911909483258fa83d811028f71c