### PR TITLE
Implementa arquivamento automatico

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,8 @@ Quando a situação de uma tarefa é alterada para **Finalizado**, o indicador d
 
 ### Arquivar tarefas
 Tarefas finalizadas podem ser arquivadas clicando no ícone de arquivo no card. Arquivadas não aparecem no kanban e ficam listadas no botão **Arquivadas** no topo da página.
+
+### Arquivamento automático
+No sábado, o sistema verifica as tarefas com situação **Finalizado** e as move
+automaticamente para o status **Arquivada**. Essa verificação é realizada
+sempre que qualquer página carrega o arquivo `config.php`.

--- a/config.php
+++ b/config.php
@@ -12,4 +12,12 @@ try {
 } catch (PDOException $e) {
     die('Erro ao conectar ao banco de dados: ' . $e->getMessage());
 }
+
+// Arquivamento automático das tarefas finalizadas no sábado
+if (date('N') == 6) { // 6 representa o sábado
+    $stmt = $pdo->prepare(
+        "UPDATE tarefas SET status = 'Arquivada', updated_at = ? WHERE status = 'Finalizado'"
+    );
+    $stmt->execute([date('Y-m-d H:i:s')]);
+}
 ?>


### PR DESCRIPTION
## Resumo
- arquiva tarefas finalizadas automaticamente aos sábados
- documenta novo comportamento

## Testes
- `php -v` *(falhou: comando não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68686a3605ac8325aea11b6a0f8fb852