### PR TITLE
Fix modal placeholder and request handling

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,5 +1,16 @@
+var detalhesRequest;
 function carregarDetalhes(id) {
-    $.get('detalhes_tarefa.php', {id: id}, function(data) {
+    // Cancela requisição anterior, se houver
+    if(detalhesRequest && detalhesRequest.readyState !== 4){
+        detalhesRequest.abort();
+    }
+    // Exibe placeholder enquanto os dados são carregados
+    $('#detalhesConteudo').html(
+        '<div class="modal-body p-3 text-center">' +
+        '<div class="spinner-border" role="status"></div>' +
+        '</div>'
+    );
+    detalhesRequest = $.get('detalhes_tarefa.php', {id: id}, function(data) {
         $('#detalhesConteudo').html(data);
         if (typeof Quill !== 'undefined') {
             window.quill = new Quill('#comentarioEditor', {theme: 'snow'});


### PR DESCRIPTION
## Summary
- cancel previous AJAX when opening task details
- add a loading spinner so old data isn't visible while fetching new details

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68686d995dc48325a56bea2a00cbf18a