### PR TITLE
Permitir edição do título das tarefas

### DIFF
--- a/atualizar_tarefa.php
+++ b/atualizar_tarefa.php
@@ -2,6 +2,7 @@
 require 'config.php';
 
 $id = $_POST['id'] ?? 0;
+$titulo = $_POST['titulo'] ?? '';
 $detalhes = $_POST['detalhes'] ?? '';
 $responsavel_id = $_POST['responsavel_id'] ?: null;
 $cliente_id = $_POST['cliente_id'] ?: null;
@@ -9,8 +10,8 @@ $tipo_atendimento = $_POST['tipo_atendimento'] ?? 'Remoto';
 
 if ($id) {
     $now = date('Y-m-d H:i:s');
-    $stmt = $pdo->prepare('UPDATE tarefas SET detalhes = ?, responsavel_id = ?, cliente_id = ?, tipo_atendimento = ?, updated_at = ? WHERE id = ?');
-    $stmt->execute([$detalhes, $responsavel_id, $cliente_id, $tipo_atendimento, $now, $id]);
+    $stmt = $pdo->prepare('UPDATE tarefas SET titulo = ?, detalhes = ?, responsavel_id = ?, cliente_id = ?, tipo_atendimento = ?, updated_at = ? WHERE id = ?');
+    $stmt->execute([$titulo, $detalhes, $responsavel_id, $cliente_id, $tipo_atendimento, $now, $id]);
     echo json_encode(['success' => true]);
 } else {
     echo json_encode(['success' => false]);

--- a/detalhes_tarefa.php
+++ b/detalhes_tarefa.php
@@ -33,7 +33,7 @@ $comentarios = $com->fetchAll(PDO::FETCH_ASSOC);
     <input type="hidden" name="id" value="<?= $tarefa['id'] ?>">
     <div class="mb-3">
       <label class="form-label">Título</label>
-      <input type="text" class="form-control" id="detalhesTitulo" name="titulo" value="<?= htmlspecialchars($tarefa['titulo']) ?>" readonly>
+      <input type="text" class="form-control" id="detalhesTitulo" name="titulo" value="<?= htmlspecialchars($tarefa['titulo']) ?>">
     </div>
     <div class="mb-3">
       <label class="form-label">Detalhes</label>


### PR DESCRIPTION
## Summary
- allow editing task title in details modal
- update PHP script to persist title changes

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68687347289483258c03c527ef103506