### PR TITLE
Implement login and user management

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -73,6 +73,20 @@ $(function() {
         }, 'json');
     });
 
+    $('#formUsuario').on('submit', function(e) {
+        e.preventDefault();
+        var id = $(this).find('input[name=id]').val();
+        var url = id ? 'atualizar_usuario.php' : 'salvar_usuario.php';
+        $.post(url, $(this).serialize(), function(resp) {
+            if (resp.success) {
+                $('#usuarioModal').modal('hide');
+                location.reload();
+            } else {
+                $('#userAlert').html('<div class="alert alert-warning alert-dismissible fade show" role="alert">'+resp.message+'<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>');
+            }
+        }, 'json');
+    });
+
     // Delegação para formulário de atualização de status
     $(document).on('submit', '#formStatus', function(e) {
         e.preventDefault();
@@ -362,5 +376,44 @@ $(function() {
         $('#clienteBusca').val('');
         $('#listaClienteModal tbody tr').show().removeClass('filtrado');
         atualizarPaginacao();
+    });
+
+    // Usuários
+    $(document).on('click', '#btnNovoUsuario', function(){
+        $('#formUsuario')[0].reset();
+        $('#formUsuario input[name=id]').val('');
+        $('#usuarioModal .modal-title').text('Cadastrar Usuário');
+        $('#listaUsuarioModal').modal('hide');
+        $('#usuarioModal').modal('show');
+    });
+
+    $(document).on('click', '.btn-editar-usuario', function(){
+        var tr = $(this).closest('tr');
+        $('#formUsuario input[name=id]').val(tr.data('id'));
+        $('#formUsuario input[name=nome]').val(tr.data('nome'));
+        $('#usuarioModal .modal-title').text('Editar Usuário');
+        $('#listaUsuarioModal').modal('hide');
+        $('#usuarioModal').modal('show');
+    });
+
+    $(document).on('click', '.btn-excluir-usuario', function(){
+        var tr = $(this).closest('tr');
+        var id = tr.data('id');
+        var nome = tr.data('nome');
+        Swal.fire({
+            title: 'Excluir "'+nome+'"?',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonText: 'Sim',
+            cancelButtonText: 'Não'
+        }).then(function(res){
+            if(res.isConfirmed){
+                $.post('excluir_usuario.php', {id:id}, function(resp){
+                    if(resp.success){
+                        location.reload();
+                    }
+                }, 'json');
+            }
+        });
     });
 });

--- a/atualizar_cliente.php
+++ b/atualizar_cliente.php
@@ -1,5 +1,5 @@
 <?php
-require 'config.php';
+require 'auth.php';
 
 $id = $_POST['id'] ?? 0;
 $cnpj = trim($_POST['cnpj'] ?? '');

--- a/atualizar_responsavel.php
+++ b/atualizar_responsavel.php
@@ -1,5 +1,5 @@
 <?php
-require 'config.php';
+require 'auth.php';
 
 $id = $_POST['id'] ?? 0;
 $nome = trim($_POST['nome'] ?? '');

--- a/atualizar_status.php
+++ b/atualizar_status.php
@@ -1,5 +1,5 @@
 <?php
-require 'config.php';
+require 'auth.php';
 
 $id = $_POST['id'] ?? 0;
 $status = $_POST['status'] ?? '';

--- a/atualizar_tarefa.php
+++ b/atualizar_tarefa.php
@@ -1,5 +1,5 @@
 <?php
-require 'config.php';
+require 'auth.php';
 
 $id = $_POST['id'] ?? 0;
 $titulo = $_POST['titulo'] ?? '';

--- a/atualizar_usuario.php
+++ b/atualizar_usuario.php
@@ -1,0 +1,23 @@
+<?php
+require 'auth.php';
+
+$id = $_POST['id'] ?? 0;
+$nome = trim($_POST['nome'] ?? '');
+
+if (!$id || $nome === '') {
+    echo json_encode(['success' => false, 'message' => 'Dados inv\u00e1lidos.']);
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT COUNT(*) FROM usuarios WHERE nome = ? AND id != ?');
+$stmt->execute([$nome, $id]);
+if ($stmt->fetchColumn() > 0) {
+    echo json_encode(['success' => false, 'message' => 'Usu\u00e1rio j\u00e1 cadastrado.']);
+    exit;
+}
+
+$stmt = $pdo->prepare('UPDATE usuarios SET nome = ? WHERE id = ?');
+$stmt->execute([$nome, $id]);
+
+echo json_encode(['success' => true]);
+?>

--- a/auth.php
+++ b/auth.php
@@ -1,0 +1,7 @@
+<?php
+require 'config.php';
+if (!isset($_SESSION['usuario_id'])) {
+    header('Location: login.php');
+    exit;
+}
+?>

--- a/config.php
+++ b/config.php
@@ -1,6 +1,8 @@
 <?php
 // config.php - Conexão com o banco de dados SQLite
 
+session_start();
+
 $databasePath = __DIR__ . '/db/pdvtarefas.db';
 
 // Define o fuso-horário padrão para evitar divergência na gravação de datas
@@ -11,6 +13,18 @@ try {
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 } catch (PDOException $e) {
     die('Erro ao conectar ao banco de dados: ' . $e->getMessage());
+}
+
+if (!isset($_SESSION['usuario_id']) && !empty($_COOKIE['manter_conectado'])) {
+    $uid = (int)$_COOKIE['manter_conectado'];
+    $stmt = $pdo->prepare('SELECT nome FROM usuarios WHERE id = ?');
+    if ($stmt->execute([$uid])) {
+        $nome = $stmt->fetchColumn();
+        if ($nome) {
+            $_SESSION['usuario_id'] = $uid;
+            $_SESSION['usuario_nome'] = $nome;
+        }
+    }
 }
 
 // Arquivamento automático das tarefas finalizadas no sábado

--- a/detalhes_tarefa.php
+++ b/detalhes_tarefa.php
@@ -1,5 +1,5 @@
 <?php
-require 'config.php';
+require 'auth.php';
 
 $id = $_GET['id'] ?? 0;
 $stmt = $pdo->prepare('SELECT t.*, r.nome AS responsavel, c.nome AS cliente FROM tarefas t
@@ -20,7 +20,7 @@ $subtarefas = $sub->fetchAll(PDO::FETCH_ASSOC);
 $statuses = ['A fazer','Fazendo','Agendado','Aguardando','Finalizado'];
 $responsaveis = $pdo->query('SELECT id, nome FROM responsaveis')->fetchAll(PDO::FETCH_ASSOC);
 $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FETCH_ASSOC);
-$com = $pdo->prepare('SELECT id, texto, imagem, created_at FROM comentarios WHERE tarefa_id = ? ORDER BY id DESC');
+$com = $pdo->prepare('SELECT c.id, c.texto, c.imagem, c.created_at, u.nome as usuario FROM comentarios c LEFT JOIN usuarios u ON c.usuario_id = u.id WHERE c.tarefa_id = ? ORDER BY c.id DESC');
 $com->execute([$id]);
 $comentarios = $com->fetchAll(PDO::FETCH_ASSOC);
 ?>
@@ -110,7 +110,9 @@ $comentarios = $com->fetchAll(PDO::FETCH_ASSOC);
   <div id="listaComentarios">
     <?php foreach ($comentarios as $c): ?>
       <div class="border p-2 mb-2">
-        <div class="small text-muted"><?= date('d/m/Y H:i', strtotime($c['created_at'])) ?></div>
+        <div class="small text-muted">
+            <?= date('d/m/Y H:i', strtotime($c['created_at'])) ?> - <span class="fst-italic" style="font-size:0.85em;"><?= htmlspecialchars($c['usuario'] ?? '') ?></span>
+        </div>
         <div><?= $c['texto'] ?></div>
         <?php if (!empty($c['imagem'])): ?>
           <img src="<?= htmlspecialchars($c['imagem']) ?>" class="img-thumbnail comentario-thumb mt-1" style="max-width:100px;cursor:pointer;" data-img="<?= htmlspecialchars($c['imagem']) ?>">

--- a/duplicar_tarefa.php
+++ b/duplicar_tarefa.php
@@ -1,5 +1,5 @@
 <?php
-require 'config.php';
+require 'auth.php';
 
 $id = $_POST['id'] ?? 0;
 

--- a/excluir_cliente.php
+++ b/excluir_cliente.php
@@ -1,5 +1,5 @@
 <?php
-require 'config.php';
+require 'auth.php';
 
 $id = $_POST['id'] ?? 0;
 

--- a/excluir_responsavel.php
+++ b/excluir_responsavel.php
@@ -1,5 +1,5 @@
 <?php
-require 'config.php';
+require 'auth.php';
 
 $id = $_POST['id'] ?? 0;
 

--- a/excluir_tarefa.php
+++ b/excluir_tarefa.php
@@ -1,5 +1,5 @@
 <?php
-require 'config.php';
+require 'auth.php';
 
 $id = $_POST['id'] ?? 0;
 

--- a/excluir_usuario.php
+++ b/excluir_usuario.php
@@ -1,0 +1,13 @@
+<?php
+require 'auth.php';
+
+$id = $_POST['id'] ?? 0;
+
+if ($id) {
+    $stmt = $pdo->prepare('DELETE FROM usuarios WHERE id = ?');
+    $stmt->execute([$id]);
+    echo json_encode(['success' => true]);
+} else {
+    echo json_encode(['success' => false]);
+}
+?>

--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
 <?php
-require 'config.php';
+require 'auth.php';
 
 // Busca tarefas do banco de dados
 function obterTarefasPorStatus(
@@ -13,7 +13,9 @@ function obterTarefasPorStatus(
   $sql =
       "SELECT t.id, t.titulo, t.detalhes, t.created_at, t.status, t.tipo_atendimento, " .
       "r.nome AS responsavel, c.nome AS cliente, " .
-      "(SELECT COUNT(*) FROM comentarios com WHERE com.tarefa_id = t.id AND com.lido = 0) AS nao_lidos " .
+      "(SELECT COUNT(*) FROM comentarios com " .
+      " LEFT JOIN comentarios_lidos l ON com.id = l.comentario_id AND l.usuario_id = :uid " .
+      " WHERE com.tarefa_id = t.id AND com.usuario_id != :uid AND l.comentario_id IS NULL) AS nao_lidos " .
       "FROM tarefas t " .
       "LEFT JOIN responsaveis r ON t.responsavel_id = r.id " .
       "LEFT JOIN clientes c ON t.cliente_id = c.id " .
@@ -37,6 +39,7 @@ function obterTarefasPorStatus(
   }
   $sql .= " ORDER BY t.id DESC";
   $stmt = $pdo->prepare($sql);
+  $stmt->bindValue(':uid', $_SESSION['usuario_id']);
   $stmt->execute($params);
   return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
@@ -62,6 +65,7 @@ $arquivadas = obterTarefasPorStatus($pdo, 'Arquivada');
 
 $responsaveis = $pdo->query('SELECT id, nome FROM responsaveis')->fetchAll(PDO::FETCH_ASSOC);
 $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FETCH_ASSOC);
+$usuarios = $pdo->query('SELECT id, nome FROM usuarios')->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <!DOCTYPE html>
 <html lang="pt-br">
@@ -82,7 +86,8 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
         <div class="d-flex">
             <button class="btn btn-light me-2" data-bs-toggle="modal" data-bs-target="#novaTarefaModal">Nova Tarefa</button>
             <button class="btn btn-light me-2" data-bs-toggle="modal" data-bs-target="#cadastroModal">Cadastro</button>
-            <button class="btn btn-light" data-bs-toggle="modal" data-bs-target="#arquivadasModal">Arquivadas</button>
+            <button class="btn btn-light me-2" data-bs-toggle="modal" data-bs-target="#arquivadasModal">Arquivadas</button>
+            <a class="btn btn-danger" href="logout.php">Sair</a>
         </div>
     </div>
     </nav>
@@ -257,7 +262,8 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
       </div>
       <div class="modal-body text-center">
       <button class="btn btn-primary me-2" data-bs-target="#listaResponsavelModal" data-bs-toggle="modal" data-bs-dismiss="modal">Responsável</button>
-        <button class="btn btn-primary" data-bs-target="#listaClienteModal" data-bs-toggle="modal" data-bs-dismiss="modal">Cliente</button>
+        <button class="btn btn-primary me-2" data-bs-target="#listaClienteModal" data-bs-toggle="modal" data-bs-dismiss="modal">Cliente</button>
+        <button class="btn btn-primary" data-bs-target="#listaUsuarioModal" data-bs-toggle="modal" data-bs-dismiss="modal">Usuário</button>
       </div>
     </div>
   </div>
@@ -338,6 +344,39 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
   </div>
   </div>
 
+<!-- Lista Usuários -->
+<div class="modal fade" id="listaUsuarioModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Usuários</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="d-flex justify-content-end mb-2">
+          <button class="btn btn-primary" id="btnNovoUsuario">Novo</button>
+        </div>
+        <table class="table table-striped">
+          <thead>
+            <tr><th>Nome</th><th>Ação</th></tr>
+          </thead>
+          <tbody>
+            <?php foreach ($usuarios as $u): ?>
+            <tr data-id="<?= $u['id'] ?>" data-nome="<?= htmlspecialchars($u['nome']) ?>">
+              <td><?= htmlspecialchars($u['nome']) ?></td>
+              <td>
+                <button class="btn btn-sm btn-secondary btn-editar-usuario">Editar</button>
+                <button class="btn btn-sm btn-danger btn-excluir-usuario">Excluir</button>
+              </td>
+            </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Modal Arquivadas -->
 <div class="modal fade" id="arquivadasModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-lg">
@@ -403,6 +442,30 @@ $clientes = $pdo->query('SELECT id, cnpj, nome FROM clientes')->fetchAll(PDO::FE
           <label class="form-label">CNPJ</label>
           <input type="text" class="form-control" name="cnpj" required>
         </div>
+        <div class="mb-3">
+          <label class="form-label">Nome</label>
+          <input type="text" class="form-control" name="nome" required>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="submit" class="btn btn-primary">Salvar</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<!-- Modal Usuário -->
+<div class="modal fade" id="usuarioModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <form class="modal-content" id="formUsuario">
+      <div class="modal-header">
+        <h5 class="modal-title">Cadastrar Usuário</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div id="userAlert"></div>
+        <input type="hidden" name="id">
         <div class="mb-3">
           <label class="form-label">Nome</label>
           <input type="text" class="form-control" name="nome" required>

--- a/init_db.php
+++ b/init_db.php
@@ -7,6 +7,10 @@ $queries = [
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         nome TEXT NOT NULL
     );",
+    "CREATE TABLE IF NOT EXISTS usuarios (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        nome TEXT NOT NULL UNIQUE
+    );",
     "CREATE TABLE IF NOT EXISTS clientes (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         cnpj TEXT UNIQUE,
@@ -32,10 +36,15 @@ $queries = [
     "CREATE TABLE IF NOT EXISTS comentarios (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         tarefa_id INTEGER NOT NULL,
+        usuario_id INTEGER,
         texto TEXT NOT NULL,
         imagem TEXT,
-        lido INTEGER DEFAULT 0,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );",
+    "CREATE TABLE IF NOT EXISTS comentarios_lidos (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        comentario_id INTEGER NOT NULL,
+        usuario_id INTEGER NOT NULL
     );"
 ];
 
@@ -54,9 +63,18 @@ $colsComentarios = $pdo->query("PRAGMA table_info(comentarios)")->fetchAll(PDO::
 if (!in_array('imagem', $colsComentarios)) {
     $pdo->exec("ALTER TABLE comentarios ADD COLUMN imagem TEXT");
 }
+if (!in_array('usuario_id', $colsComentarios)) {
+    $pdo->exec("ALTER TABLE comentarios ADD COLUMN usuario_id INTEGER");
+}
 if (!in_array('lido', $colsComentarios)) {
     $pdo->exec("ALTER TABLE comentarios ADD COLUMN lido INTEGER DEFAULT 0");
 }
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS comentarios_lidos (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    comentario_id INTEGER NOT NULL,
+    usuario_id INTEGER NOT NULL
+);");
 
 echo "Banco de dados inicializado com sucesso.\n";
 ?>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,54 @@
+<?php
+require 'config.php';
+
+$usuarios = $pdo->query('SELECT id, nome FROM usuarios ORDER BY nome')->fetchAll(PDO::FETCH_ASSOC);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $uid = $_POST['usuario_id'] ?? '';
+    if ($uid) {
+        $stmt = $pdo->prepare('SELECT nome FROM usuarios WHERE id = ?');
+        $stmt->execute([$uid]);
+        $nome = $stmt->fetchColumn();
+        if ($nome) {
+            $_SESSION['usuario_id'] = $uid;
+            $_SESSION['usuario_nome'] = $nome;
+            if (!empty($_POST['manter'])) {
+                setcookie('manter_conectado', $uid, time()+60*60*24*30, '/');
+            } else {
+                setcookie('manter_conectado', '', time()-3600, '/');
+            }
+            header('Location: index.php');
+            exit;
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Login</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="d-flex align-items-center justify-content-center vh-100">
+<div class="card p-4" style="min-width:300px;">
+    <h5 class="mb-3">Escolha o Usuário</h5>
+    <form method="POST">
+        <div class="mb-3">
+            <select name="usuario_id" class="form-select" required>
+                <option value="">Selecione...</option>
+                <?php foreach ($usuarios as $u): ?>
+                    <option value="<?= $u['id'] ?>"><?= htmlspecialchars($u['nome']) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" name="manter" id="manter">
+            <label class="form-check-label" for="manter">Manter Conectado</label>
+        </div>
+        <button type="submit" class="btn btn-primary w-100">Entrar</button>
+    </form>
+</div>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,8 @@
+<?php
+require 'config.php';
+session_unset();
+session_destroy();
+setcookie('manter_conectado', '', time()-3600, '/');
+header('Location: login.php');
+exit;
+?>

--- a/marcar_comentarios_lidos.php
+++ b/marcar_comentarios_lidos.php
@@ -1,9 +1,15 @@
 <?php
-require 'config.php';
+require 'auth.php';
 $id = $_POST['id'] ?? 0;
 if($id){
-    $stmt = $pdo->prepare('UPDATE comentarios SET lido = 1 WHERE tarefa_id = ?');
+    $userId = $_SESSION['usuario_id'];
+    $stmt = $pdo->prepare('SELECT id FROM comentarios WHERE tarefa_id = ?');
     $stmt->execute([$id]);
+    $comentarios = $stmt->fetchAll(PDO::FETCH_COLUMN);
+    $ins = $pdo->prepare('INSERT OR IGNORE INTO comentarios_lidos (comentario_id, usuario_id) VALUES (?, ?)');
+    foreach($comentarios as $cid){
+        $ins->execute([$cid, $userId]);
+    }
 }
 echo json_encode(['success'=>true]);
 ?>

--- a/obter_tarefas.php
+++ b/obter_tarefas.php
@@ -1,10 +1,12 @@
 <?php
-require 'config.php';
+require 'auth.php';
 
 function obterTarefasPorStatus($pdo, $status, $cadastroDe = null, $cadastroAte = null, $modificacaoDe = null, $modificacaoAte = null) {
     $sql = "SELECT t.id, t.titulo, t.detalhes, t.created_at, t.status, t.tipo_atendimento, " .
            "r.nome AS responsavel, c.nome AS cliente, " .
-           "(SELECT COUNT(*) FROM comentarios com WHERE com.tarefa_id = t.id AND com.lido = 0) AS nao_lidos " .
+           "(SELECT COUNT(*) FROM comentarios com " .
+           " LEFT JOIN comentarios_lidos l ON com.id = l.comentario_id AND l.usuario_id = :uid " .
+           " WHERE com.tarefa_id = t.id AND com.usuario_id != :uid AND l.comentario_id IS NULL) AS nao_lidos " .
            "FROM tarefas t " .
            "LEFT JOIN responsaveis r ON t.responsavel_id = r.id " .
            "LEFT JOIN clientes c ON t.cliente_id = c.id " .
@@ -28,6 +30,7 @@ function obterTarefasPorStatus($pdo, $status, $cadastroDe = null, $cadastroAte =
     }
     $sql .= " ORDER BY t.id DESC";
     $stmt = $pdo->prepare($sql);
+    $stmt->bindValue(':uid', $_SESSION['usuario_id']);
     $stmt->execute($params);
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }

--- a/salvar_cliente.php
+++ b/salvar_cliente.php
@@ -1,5 +1,5 @@
 <?php
-require 'config.php';
+require 'auth.php';
 
 $cnpj = trim($_POST['cnpj'] ?? '');
 $nome = trim($_POST['nome'] ?? '');

--- a/salvar_comentario.php
+++ b/salvar_comentario.php
@@ -1,5 +1,5 @@
 <?php
-require 'config.php';
+require 'auth.php';
 
 $tarefa_id = $_POST['tarefa_id'] ?? 0;
 $texto = $_POST['texto'] ?? '';
@@ -20,8 +20,11 @@ if (!empty($_FILES['imagem']['name'])) {
 
 if ($tarefa_id && $texto !== '') {
     $now = date('Y-m-d H:i:s');
-    $stmt = $pdo->prepare('INSERT INTO comentarios (tarefa_id, texto, imagem, created_at) VALUES (?, ?, ?, ?)');
-    $stmt->execute([$tarefa_id, $texto, $imagemPath, $now]);
+$userId = $_SESSION['usuario_id'];
+$stmt = $pdo->prepare('INSERT INTO comentarios (tarefa_id, usuario_id, texto, imagem, created_at) VALUES (?, ?, ?, ?, ?)');
+$stmt->execute([$tarefa_id, $userId, $texto, $imagemPath, $now]);
+$comentarioId = $pdo->lastInsertId();
+$pdo->prepare('INSERT INTO comentarios_lidos (comentario_id, usuario_id) VALUES (?, ?)')->execute([$comentarioId, $userId]);
     echo json_encode(['success' => true]);
 } else {
     echo json_encode(['success' => false]);

--- a/salvar_responsavel.php
+++ b/salvar_responsavel.php
@@ -1,5 +1,5 @@
 <?php
-require 'config.php';
+require 'auth.php';
 
 $nome = trim($_POST['nome'] ?? '');
 

--- a/salvar_tarefa.php
+++ b/salvar_tarefa.php
@@ -1,5 +1,5 @@
 <?php
-require 'config.php';
+require 'auth.php';
 
 $titulo = $_POST['titulo'] ?? '';
 $detalhes = $_POST['detalhes'] ?? '';

--- a/salvar_usuario.php
+++ b/salvar_usuario.php
@@ -1,0 +1,22 @@
+<?php
+require 'auth.php';
+
+$nome = trim($_POST['nome'] ?? '');
+
+if ($nome === '') {
+    echo json_encode(['success' => false, 'message' => 'Nome \u00e9 obrigat\u00f3rio.']);
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT COUNT(*) FROM usuarios WHERE nome = ?');
+$stmt->execute([$nome]);
+if ($stmt->fetchColumn() > 0) {
+    echo json_encode(['success' => false, 'message' => 'Usu\u00e1rio j\u00e1 cadastrado.']);
+    exit;
+}
+
+$stmt = $pdo->prepare('INSERT INTO usuarios (nome) VALUES (?)');
+$stmt->execute([$nome]);
+
+echo json_encode(['success' => true]);
+?>


### PR DESCRIPTION
## Summary
- implement auth checking and session-based login
- add User CRUD with modal dialogs
- track unread comments per user
- create login and logout pages
- enhance DB schema for users and per-user comment read flags

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68687921786c83258d02e7cf0f0d2d95