### PR TITLE
Adicionar usuário ADM ao init_db

### DIFF
--- a/init_db.php
+++ b/init_db.php
@@ -52,6 +52,13 @@ foreach ($queries as $query) {
     $pdo->exec($query);
 }
 
+// Insere usuário padrão "ADM" caso não exista
+$stmt = $pdo->prepare('SELECT COUNT(*) FROM usuarios WHERE nome = ?');
+$stmt->execute(['ADM']);
+if ($stmt->fetchColumn() == 0) {
+    $pdo->prepare('INSERT INTO usuarios (nome) VALUES (?)')->execute(['ADM']);
+}
+
 // Adiciona coluna tipo_atendimento se não existir
 $cols = $pdo->query("PRAGMA table_info(tarefas)")->fetchAll(PDO::FETCH_COLUMN, 1);
 if (!in_array('tipo_atendimento', $cols)) {


### PR DESCRIPTION
## Summary
- inserir usuário padrão "ADM" durante a inicialização do banco

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6868832758e88325ba6cc7093c467a17