### PR TITLE
Corrige preview de detalhes sem mbstring

### DIFF
--- a/index.php
+++ b/index.php
@@ -150,8 +150,8 @@ $usuarios = $pdo->query('SELECT id, nome FROM usuarios')->fetchAll(PDO::FETCH_AS
                         }
                     }
 
-                    $detalhesPreview = mb_strlen($tarefa['detalhes']) > 200
-                        ? mb_substr($tarefa['detalhes'], 0, 200) . '...'
+                    $detalhesPreview = strlen($tarefa['detalhes']) > 200
+                        ? substr($tarefa['detalhes'],0,200) . '...'
                         : $tarefa['detalhes'];
                 ?>
                 <div class="card mb-2 tarefa-card position-relative" data-id="<?= $tarefa['id'] ?>">

--- a/obter_tarefas.php
+++ b/obter_tarefas.php
@@ -76,8 +76,8 @@ foreach ($statuses as $status) {
                 $badge = 'danger';
             }
         }
-        $detalhesPreview = mb_strlen($tarefa['detalhes']) > 200
-            ? mb_substr($tarefa['detalhes'], 0, 200) . '...'
+        $detalhesPreview = strlen($tarefa['detalhes']) > 200
+            ? substr($tarefa['detalhes'],0,200) . '...'
             : $tarefa['detalhes'];
         ?>
         <div class="card mb-2 tarefa-card position-relative" data-id="<?= $tarefa['id'] ?>">


### PR DESCRIPTION
## Resumo
- substitui uso de `mb_strlen` e `mb_substr` por `strlen` e `substr`

## Testes
- `php` indisponível no ambiente, sem testes automatizados

------
https://chatgpt.com/codex/tasks/task_e_686886a0a2fc8325868638cf4bf519a3