### PR TITLE
Fix JSON responses and remove trailing PHP tags

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -4,4 +4,3 @@ if (!isset($_SESSION['usuario_id'])) {
     header('Location: login.php');
     exit;
 }
-?>

--- a/config.php
+++ b/config.php
@@ -57,4 +57,3 @@ if (date('N') == 6) { // 6 representa o sábado
     );
     $stmt->execute([date('Y-m-d H:i:s')]);
 }
-?>

--- a/obter_tarefas.php
+++ b/obter_tarefas.php
@@ -116,3 +116,4 @@ foreach ($statuses as $status) {
 
 header('Content-Type: application/json');
 echo json_encode($result);
+exit;

--- a/salvar_tarefa.php
+++ b/salvar_tarefa.php
@@ -26,4 +26,3 @@ if ($isAjax) {
 
 header('Location: index.php');
 exit;
-?>


### PR DESCRIPTION
## Summary
- ensure obter_tarefas.php stops after outputting JSON
- remove closing PHP tags from several scripts to avoid unwanted output

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68688a6e9d94832582a5bc2e6bf06b48