### PR TITLE
Fix dynamic status loading

### DIFF
--- a/index.php
+++ b/index.php
@@ -44,7 +44,11 @@ function obterTarefasPorStatus(
   return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
-$statuses = ['A fazer', 'Fazendo', 'Agendado', 'Aguardando', 'Finalizado'];
+$defaultStatuses = ['A fazer', 'Fazendo', 'Agendado', 'Aguardando', 'Finalizado'];
+$stmt = $pdo->query("SELECT DISTINCT status FROM tarefas");
+$dbStatuses = $stmt->fetchAll(PDO::FETCH_COLUMN);
+$statuses = array_unique(array_merge($defaultStatuses, $dbStatuses));
+$statuses = array_values(array_diff($statuses, ['Arquivada']));
 $tarefas = [];
 // Filtros de data
 $dataCadastroDe = $_GET['data_cadastro_de'] ?? null;

--- a/obter_tarefas.php
+++ b/obter_tarefas.php
@@ -35,7 +35,11 @@ function obterTarefasPorStatus($pdo, $status, $cadastroDe = null, $cadastroAte =
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
-$statuses = ['A fazer', 'Fazendo', 'Agendado', 'Aguardando', 'Finalizado'];
+$defaultStatuses = ['A fazer', 'Fazendo', 'Agendado', 'Aguardando', 'Finalizado'];
+$stmt = $pdo->query("SELECT DISTINCT status FROM tarefas");
+$dbStatuses = $stmt->fetchAll(PDO::FETCH_COLUMN);
+$statuses = array_unique(array_merge($defaultStatuses, $dbStatuses));
+$statuses = array_values(array_diff($statuses, ['Arquivada']));
 $dataCadastroDe = $_GET['data_cadastro_de'] ?? null;
 $dataCadastroAte = $_GET['data_cadastro_ate'] ?? null;
 $dataModificacaoDe = $_GET['data_modificacao_de'] ?? null;


### PR DESCRIPTION
## Summary
- load statuses dynamically from the database for both the kanban board and the fetch endpoint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868934171888325989ea92798c7ffb4