### PR TITLE
Fix auth handler and comment saving

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -27,11 +27,17 @@ function atualizarKanban(callback){
         dados = $('#filtrosForm').serialize();
     }
     $.get('obter_tarefas.php', dados, function(resp){
+        if(resp.error === 'not_authenticated'){
+            window.location = 'login.php';
+            return;
+        }
         for(var status in resp){
             $('.tarefa-col[data-status="'+status+'"]').html(resp[status]);
         }
         if(typeof callback === 'function') callback();
-    }, 'json');
+    }, 'json').fail(function(){
+        window.location = 'login.php';
+    });
 }
 
 $(function() {

--- a/auth.php
+++ b/auth.php
@@ -1,6 +1,12 @@
 <?php
 require 'config.php';
+
 if (!isset($_SESSION['usuario_id'])) {
-    header('Location: login.php');
+    if (strtolower($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'xmlhttprequest') {
+        header('Content-Type: application/json');
+        echo json_encode(['error' => 'not_authenticated']);
+    } else {
+        header('Location: login.php');
+    }
     exit;
 }

--- a/salvar_comentario.php
+++ b/salvar_comentario.php
@@ -20,13 +20,12 @@ if (!empty($_FILES['imagem']['name'])) {
 
 if ($tarefa_id && $texto !== '') {
     $userId = $_SESSION['usuario_id'];
+    $now = date('Y-m-d H:i:s');
     $stmt = $pdo->prepare('INSERT INTO comentarios (tarefa_id, usuario_id, texto, imagem, created_at) VALUES (?, ?, ?, ?, ?)');
     $stmt->execute([$tarefa_id, $userId, $texto, $imagemPath, $now]);
     $comentarioId = $pdo->lastInsertId();
     $pdo->prepare('INSERT INTO comentarios_lidos (comentario_id, usuario_id) VALUES (?, ?)')->execute([$comentarioId, $userId]);
-    $stmt->execute([$tarefa_id, $texto, $imagemPath, $now]);
     echo json_encode(['success' => true]);
 } else {
     echo json_encode(['success' => false]);
 }
-?>


### PR DESCRIPTION
## Summary
- improve auth handler to return JSON error for AJAX
- handle not-authenticated response in `app.js`
- fix undefined variable and duplicate query in `salvar_comentario.php`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868a564049c8325b87f5858775cf868