### PR TITLE
Implementa histórico de alterações nas tarefas

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -163,6 +163,15 @@ $(function() {
         });
     });
 
+    $(document).on('click', '#btnVerAlteracoes', function(){
+        var id = $('#formTarefaDetalhes input[name=id]').val();
+        $('#alteracoesConteudo').html('<div class="text-center p-3"><div class="spinner-border"></div></div>');
+        $.get('obter_alteracoes.php', {id:id}, function(html){
+            $('#alteracoesConteudo').html(html);
+            $('#alteracoesModal').modal('show');
+        });
+    });
+
     // Drag and drop das tarefas
     var isDragging = false;
     $('.tarefa-col').sortable({

--- a/atualizar_status.php
+++ b/atualizar_status.php
@@ -1,5 +1,6 @@
 <?php
 require 'auth.php';
+require 'funcoes.php';
 
 $id = $_POST['id'] ?? 0;
 $status = $_POST['status'] ?? '';
@@ -9,6 +10,7 @@ if ($id && $status) {
     $now = date('Y-m-d H:i:s');
     $stmt = $pdo->prepare('UPDATE tarefas SET status = ?, updated_at = ? WHERE id = ?');
     $stmt->execute([$status, $now, $id]);
+    registrarAlteracao($pdo, $id, $_SESSION['usuario_id'], 'Status alterado para ' . $status);
     echo json_encode(['success' => true]);
 } else {
     echo json_encode(['success' => false]);

--- a/atualizar_tarefa.php
+++ b/atualizar_tarefa.php
@@ -1,5 +1,6 @@
 <?php
 require 'auth.php';
+require 'funcoes.php';
 
 $id = $_POST['id'] ?? 0;
 $titulo = $_POST['titulo'] ?? '';
@@ -12,6 +13,7 @@ if ($id) {
     $now = date('Y-m-d H:i:s');
     $stmt = $pdo->prepare('UPDATE tarefas SET titulo = ?, detalhes = ?, responsavel_id = ?, cliente_id = ?, tipo_atendimento = ?, updated_at = ? WHERE id = ?');
     $stmt->execute([$titulo, $detalhes, $responsavel_id, $cliente_id, $tipo_atendimento, $now, $id]);
+    registrarAlteracao($pdo, $id, $_SESSION['usuario_id'], 'Detalhes atualizados');
     echo json_encode(['success' => true]);
 } else {
     echo json_encode(['success' => false]);

--- a/config.php
+++ b/config.php
@@ -98,6 +98,13 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS comentarios_lidos (
     comentario_id INTEGER NOT NULL,
     usuario_id INTEGER NOT NULL
 );");
+$pdo->exec("CREATE TABLE IF NOT EXISTS alteracoes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tarefa_id INTEGER NOT NULL,
+    usuario_id INTEGER NOT NULL,
+    descricao TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);");
 
 if (!isset($_SESSION['usuario_id']) && !empty($_COOKIE['manter_conectado'])) {
     $uid = (int)$_COOKIE['manter_conectado'];

--- a/detalhes_tarefa.php
+++ b/detalhes_tarefa.php
@@ -131,6 +131,7 @@ $comentarios = $com->fetchAll(PDO::FETCH_ASSOC);
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-danger me-auto" id="btnExcluirTarefa">Excluir</button>
+  <button type="button" class="btn btn-info" id="btnVerAlteracoes">Ver Alterações</button>
   <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
 </div>
 <script>

--- a/duplicar_tarefa.php
+++ b/duplicar_tarefa.php
@@ -1,5 +1,6 @@
 <?php
 require 'auth.php';
+require 'funcoes.php';
 
 $id = $_POST['id'] ?? 0;
 
@@ -31,5 +32,8 @@ $stmt->execute([
     $now
 ]);
 
-echo json_encode(['success' => true, 'id' => $pdo->lastInsertId()]);
+$novoId = $pdo->lastInsertId();
+registrarAlteracao($pdo, $novoId, $_SESSION['usuario_id'], 'Tarefa duplicada');
+
+echo json_encode(['success' => true, 'id' => $novoId]);
 ?>

--- a/excluir_tarefa.php
+++ b/excluir_tarefa.php
@@ -1,9 +1,11 @@
 <?php
 require 'auth.php';
+require 'funcoes.php';
 
 $id = $_POST['id'] ?? 0;
 
 if ($id) {
+    registrarAlteracao($pdo, $id, $_SESSION['usuario_id'], 'Tarefa excluída');
     $pdo->prepare('DELETE FROM comentarios WHERE tarefa_id = ?')->execute([$id]);
     $pdo->prepare('DELETE FROM subtarefas WHERE tarefa_id = ?')->execute([$id]);
     $pdo->prepare('DELETE FROM tarefas WHERE id = ?')->execute([$id]);

--- a/funcoes.php
+++ b/funcoes.php
@@ -1,0 +1,6 @@
+<?php
+function registrarAlteracao(PDO $pdo, $tarefaId, $usuarioId, $descricao){
+    $stmt = $pdo->prepare('INSERT INTO alteracoes (tarefa_id, usuario_id, descricao, created_at) VALUES (?, ?, ?, ?)');
+    $stmt->execute([$tarefaId, $usuarioId, $descricao, date('Y-m-d H:i:s')]);
+}
+?>

--- a/index.php
+++ b/index.php
@@ -497,6 +497,19 @@ $usuarios = $pdo->query('SELECT id, nome FROM usuarios')->fetchAll(PDO::FETCH_AS
   </div>
 </div>
 
+<div class="modal fade" id="alteracoesModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Alterações</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body" id="alteracoesConteudo">
+      </div>
+    </div>
+  </div>
+</div>
+
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
 <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
@@ -506,6 +519,6 @@ $usuarios = $pdo->query('SELECT id, nome FROM usuarios')->fetchAll(PDO::FETCH_AS
 <script>
 var clientesData = <?php echo json_encode($clientes); ?>;
 </script>
-<script src="assets/js/app.js?v=1.0.6"></script>
+<script src="assets/js/app.js?v=1.0.7"></script>
 </body>
 </html>

--- a/init_db.php
+++ b/init_db.php
@@ -45,6 +45,13 @@ $queries = [
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         comentario_id INTEGER NOT NULL,
         usuario_id INTEGER NOT NULL
+    );",
+    "CREATE TABLE IF NOT EXISTS alteracoes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        tarefa_id INTEGER NOT NULL,
+        usuario_id INTEGER NOT NULL,
+        descricao TEXT NOT NULL,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
     );"
 ];
 
@@ -81,6 +88,13 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS comentarios_lidos (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     comentario_id INTEGER NOT NULL,
     usuario_id INTEGER NOT NULL
+);");
+$pdo->exec("CREATE TABLE IF NOT EXISTS alteracoes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tarefa_id INTEGER NOT NULL,
+    usuario_id INTEGER NOT NULL,
+    descricao TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );");
 
 echo "Banco de dados inicializado com sucesso.\n";

--- a/obter_alteracoes.php
+++ b/obter_alteracoes.php
@@ -1,0 +1,22 @@
+<?php
+require 'auth.php';
+
+$id = $_GET['id'] ?? 0;
+$stmt = $pdo->prepare('SELECT a.descricao, u.nome AS usuario, a.created_at FROM alteracoes a LEFT JOIN usuarios u ON a.usuario_id = u.id WHERE a.tarefa_id = ? ORDER BY a.id DESC');
+$stmt->execute([$id]);
+$alteracoes = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<table class="table table-striped">
+  <thead>
+    <tr><th>Alteração</th><th>Usuário</th><th>Data/Hora</th></tr>
+  </thead>
+  <tbody>
+  <?php foreach($alteracoes as $alt): ?>
+    <tr>
+      <td><?= htmlspecialchars($alt['descricao']) ?></td>
+      <td><?= htmlspecialchars($alt['usuario']) ?></td>
+      <td><?= date('d/m/Y H:i', strtotime($alt['created_at'])) ?></td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>

--- a/salvar_tarefa.php
+++ b/salvar_tarefa.php
@@ -1,5 +1,6 @@
 <?php
 require 'auth.php';
+require 'funcoes.php';
 
 $titulo = $_POST['titulo'] ?? '';
 $detalhes = $_POST['detalhes'] ?? '';
@@ -16,6 +17,8 @@ $updated_at = $created_at;
 if ($titulo) {
     $stmt = $pdo->prepare('INSERT INTO tarefas (titulo, detalhes, responsavel_id, cliente_id, tipo_atendimento, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
     $stmt->execute([$titulo, $detalhes, $responsavel_id, $cliente_id, $tipo_atendimento, 'A fazer', $created_at, $updated_at]);
+    $tarefaId = $pdo->lastInsertId();
+    registrarAlteracao($pdo, $tarefaId, $_SESSION['usuario_id'], 'Tarefa criada');
 }
 
 $isAjax = strtolower($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'xmlhttprequest';


### PR DESCRIPTION
## Resumo
- cria tabela `alteracoes`
- registra atualizações de tarefas
- inclui função `registrarAlteracao`
- adiciona botão **Ver Alterações**
- exibe histórico em modal dedicado

## Testes
- *N/A: projeto não possui testes automatizados*
- `php` indisponível, impossibilitando execução de `php -l`

------
https://chatgpt.com/codex/tasks/task_e_686c171b45b88325a43cc2df9789926b