### PR TITLE
Implementa campo de agendamento

### DIFF
--- a/atualizar_status.php
+++ b/atualizar_status.php
@@ -4,12 +4,21 @@ require 'funcoes.php';
 
 $id = $_POST['id'] ?? 0;
 $status = $_POST['status'] ?? '';
+$dataHora = $_POST['data_hora_agendamento'] ?? null;
+if ($dataHora) {
+    $dataHora = str_replace('T', ' ', $dataHora);
+}
 
 if ($id && $status) {
     // Atualiza a situação e registra a data/hora de alteração
     $now = date('Y-m-d H:i:s');
-    $stmt = $pdo->prepare('UPDATE tarefas SET status = ?, updated_at = ? WHERE id = ?');
-    $stmt->execute([$status, $now, $id]);
+    if ($status === 'Agendado') {
+        $stmt = $pdo->prepare('UPDATE tarefas SET status = ?, data_hora_agendamento = ?, updated_at = ? WHERE id = ?');
+        $stmt->execute([$status, $dataHora, $now, $id]);
+    } else {
+        $stmt = $pdo->prepare('UPDATE tarefas SET status = ?, data_hora_agendamento = NULL, updated_at = ? WHERE id = ?');
+        $stmt->execute([$status, $now, $id]);
+    }
     registrarAlteracao($pdo, $id, $_SESSION['usuario_id'], 'Status alterado para ' . $status);
     echo json_encode(['success' => true]);
 } else {

--- a/config.php
+++ b/config.php
@@ -38,6 +38,7 @@ try {
                 responsavel_id INTEGER,
                 cliente_id INTEGER,
                 tipo_atendimento TEXT DEFAULT 'Remoto',
+                data_hora_agendamento DATETIME,
                 status TEXT NOT NULL DEFAULT 'A fazer',
                 created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
                 updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
@@ -80,6 +81,9 @@ try {
 $cols = $pdo->query("PRAGMA table_info(tarefas)")->fetchAll(PDO::FETCH_COLUMN, 1);
 if (!in_array('tipo_atendimento', $cols)) {
     $pdo->exec("ALTER TABLE tarefas ADD COLUMN tipo_atendimento TEXT DEFAULT 'Remoto'");
+}
+if (!in_array('data_hora_agendamento', $cols)) {
+    $pdo->exec("ALTER TABLE tarefas ADD COLUMN data_hora_agendamento DATETIME");
 }
 
 $colsComentarios = $pdo->query("PRAGMA table_info(comentarios)")->fetchAll(PDO::FETCH_COLUMN, 1);

--- a/detalhes_tarefa.php
+++ b/detalhes_tarefa.php
@@ -103,6 +103,10 @@ $comentarios = $com->fetchAll(PDO::FETCH_ASSOC);
         <?php endforeach; ?>
       </select>
     </div>
+    <div class="mb-3" id="campoAgendamento" style="display:none;">
+      <label class="form-label">Data e Hora de Agendamento</label>
+      <input type="datetime-local" class="form-control" name="data_hora_agendamento" value="<?= $tarefa['data_hora_agendamento'] ? date('Y-m-d\TH:i', strtotime($tarefa['data_hora_agendamento'])) : '' ?>">
+    </div>
     <button type="submit" class="btn btn-secondary">Salvar Situação</button>
   </form>
 
@@ -135,14 +139,26 @@ $comentarios = $com->fetchAll(PDO::FETCH_ASSOC);
   <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
 </div>
 <script>
-$(function(){
-    $('#detClienteFiltro').on('keyup', function(){
-        var termo = $(this).val().toLowerCase();
-        $('#detClienteDropdownMenu a.dropdown-item').each(function(){
-            var txt = $(this).text().toLowerCase();
-            $(this).toggle(txt.indexOf(termo) !== -1);
-        });
-    });
+  $(function(){
+      $('#detClienteFiltro').on('keyup', function(){
+          var termo = $(this).val().toLowerCase();
+          $('#detClienteDropdownMenu a.dropdown-item').each(function(){
+              var txt = $(this).text().toLowerCase();
+              $(this).toggle(txt.indexOf(termo) !== -1);
+          });
+      });
+
+      function toggleAgendamento(){
+          var sel = $('#formStatus select[name=status]').val();
+          if(sel === 'Agendado'){
+              $('#campoAgendamento').show();
+          } else {
+              $('#campoAgendamento').hide();
+              $('#campoAgendamento input').val('');
+          }
+      }
+      toggleAgendamento();
+      $('#formStatus select[name=status]').on('change', toggleAgendamento);
 
     $('#detClienteDropdownMenu').on('click', 'a.dropdown-item', function(e){
         e.preventDefault();

--- a/duplicar_tarefa.php
+++ b/duplicar_tarefa.php
@@ -9,7 +9,7 @@ if (!$id) {
     exit;
 }
 
-$stmt = $pdo->prepare('SELECT titulo, detalhes, responsavel_id, cliente_id, tipo_atendimento FROM tarefas WHERE id = ?');
+$stmt = $pdo->prepare('SELECT titulo, detalhes, responsavel_id, cliente_id, tipo_atendimento, data_hora_agendamento FROM tarefas WHERE id = ?');
 $stmt->execute([$id]);
 $tarefa = $stmt->fetch(PDO::FETCH_ASSOC);
 
@@ -20,13 +20,14 @@ if (!$tarefa) {
 
 $now = date('Y-m-d H:i:s');
 
-$stmt = $pdo->prepare('INSERT INTO tarefas (titulo, detalhes, responsavel_id, cliente_id, tipo_atendimento, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
+$stmt = $pdo->prepare('INSERT INTO tarefas (titulo, detalhes, responsavel_id, cliente_id, tipo_atendimento, data_hora_agendamento, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
 $stmt->execute([
     $tarefa['titulo'],
     $tarefa['detalhes'],
     $tarefa['responsavel_id'],
     $tarefa['cliente_id'],
     $tarefa['tipo_atendimento'],
+    $tarefa['data_hora_agendamento'],
     'A fazer',
     $now,
     $now

--- a/index.php
+++ b/index.php
@@ -11,7 +11,7 @@ function obterTarefasPorStatus(
   $modificacaoAte = null
 ) {
   $sql =
-      "SELECT t.id, t.titulo, t.detalhes, t.created_at, t.status, t.tipo_atendimento, " .
+      "SELECT t.id, t.titulo, t.detalhes, t.created_at, t.status, t.tipo_atendimento, t.data_hora_agendamento, " .
       "r.nome AS responsavel, c.nome AS cliente, " .
       "(SELECT COUNT(*) FROM comentarios com " .
       " LEFT JOIN comentarios_lidos l ON com.id = l.comentario_id AND l.usuario_id = :uid " .

--- a/init_db.php
+++ b/init_db.php
@@ -23,6 +23,7 @@ $queries = [
         responsavel_id INTEGER,
         cliente_id INTEGER,
         tipo_atendimento TEXT DEFAULT 'Remoto',
+        data_hora_agendamento DATETIME,
         status TEXT NOT NULL DEFAULT 'A fazer',
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
         updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
@@ -70,6 +71,9 @@ if ($stmt->fetchColumn() == 0) {
 $cols = $pdo->query("PRAGMA table_info(tarefas)")->fetchAll(PDO::FETCH_COLUMN, 1);
 if (!in_array('tipo_atendimento', $cols)) {
     $pdo->exec("ALTER TABLE tarefas ADD COLUMN tipo_atendimento TEXT DEFAULT 'Remoto'");
+}
+if (!in_array('data_hora_agendamento', $cols)) {
+    $pdo->exec("ALTER TABLE tarefas ADD COLUMN data_hora_agendamento DATETIME");
 }
 
 // Adiciona colunas em comentarios se não existirem

--- a/obter_tarefas.php
+++ b/obter_tarefas.php
@@ -2,7 +2,7 @@
 require 'auth.php';
 
 function obterTarefasPorStatus($pdo, $status, $cadastroDe = null, $cadastroAte = null, $modificacaoDe = null, $modificacaoAte = null) {
-    $sql = "SELECT t.id, t.titulo, t.detalhes, t.created_at, t.status, t.tipo_atendimento, " .
+    $sql = "SELECT t.id, t.titulo, t.detalhes, t.created_at, t.status, t.tipo_atendimento, t.data_hora_agendamento, " .
            "r.nome AS responsavel, c.nome AS cliente, " .
            "(SELECT COUNT(*) FROM comentarios com " .
            " LEFT JOIN comentarios_lidos l ON com.id = l.comentario_id AND l.usuario_id = :uid " .

--- a/salvar_tarefa.php
+++ b/salvar_tarefa.php
@@ -7,6 +7,7 @@ $detalhes = $_POST['detalhes'] ?? '';
 $responsavel_id = $_POST['responsavel_id'] ?: null;
 $cliente_id = $_POST['cliente_id'] ?: null;
 $tipo_atendimento = $_POST['tipo_atendimento'] ?? 'Remoto';
+$data_hora_agendamento = null;
 $created_at = $_POST['created_at'] ?? date('Y-m-d H:i:s');
 
 if ($created_at) {
@@ -15,8 +16,8 @@ if ($created_at) {
 $updated_at = $created_at;
 
 if ($titulo) {
-    $stmt = $pdo->prepare('INSERT INTO tarefas (titulo, detalhes, responsavel_id, cliente_id, tipo_atendimento, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
-    $stmt->execute([$titulo, $detalhes, $responsavel_id, $cliente_id, $tipo_atendimento, 'A fazer', $created_at, $updated_at]);
+    $stmt = $pdo->prepare('INSERT INTO tarefas (titulo, detalhes, responsavel_id, cliente_id, tipo_atendimento, data_hora_agendamento, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
+    $stmt->execute([$titulo, $detalhes, $responsavel_id, $cliente_id, $tipo_atendimento, $data_hora_agendamento, 'A fazer', $created_at, $updated_at]);
     $tarefaId = $pdo->lastInsertId();
     registrarAlteracao($pdo, $tarefaId, $_SESSION['usuario_id'], 'Tarefa criada');
 }


### PR DESCRIPTION
## Resumo
- adiciona coluna `data_hora_agendamento` na tabela de tarefas
- exibe campo de data e hora somente quando a situação está como **Agendado**
- permite salvar e duplicar tarefas com data/hora de agendamento
- atualiza consultas e inicialização do banco

## Testes
- `php -l config.php` *(falhou: comando não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_686c4095fd708325a32bdc98af35310f