### PR TITLE
Implement WhatsApp reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,8 @@ Tarefas finalizadas podem ser arquivadas clicando no ícone de arquivo no card. 
 No sábado, o sistema verifica as tarefas com situação **Finalizado** e as move
 automaticamente para o status **Arquivada**. Essa verificação é realizada
 sempre que qualquer página carrega o arquivo `config.php`.
+
+### Lembretes de agendamento
+O script `send_reminders.php` envia mensagens de WhatsApp quando uma tarefa
+agendada está a 30, 20 ou 10 minutos de iniciar. Para utilizá‑lo,
+agende a execução desse arquivo via `cron` ou ferramenta similar.

--- a/config.php
+++ b/config.php
@@ -8,6 +8,14 @@ $databasePath = __DIR__ . '/db/pdvtarefas.db';
 // Define o fuso-horário padrão para evitar divergência na gravação de datas
 date_default_timezone_set('America/Sao_Paulo');
 
+// Configurações da API de mensagens do WhatsApp
+$whatsappConfig = [
+    'endpoint'   => 'http://38.210.212.113:3000/client/sendMessage',
+    'sessionId'  => 'pvparaloja',
+    'apiKey'     => 'pdvparaloja_emws',
+    'numbers'    => ['559884029080', '559888992974']
+];
+
 try {
     $pdo = new PDO('sqlite:' . $databasePath);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
@@ -108,6 +116,12 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS alteracoes (
     usuario_id INTEGER NOT NULL,
     descricao TEXT NOT NULL,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS lembretes_enviados (
+    tarefa_id INTEGER NOT NULL,
+    momento INTEGER NOT NULL,
+    PRIMARY KEY (tarefa_id, momento)
 );");
 
 if (!isset($_SESSION['usuario_id']) && !empty($_COOKIE['manter_conectado'])) {

--- a/init_db.php
+++ b/init_db.php
@@ -53,6 +53,11 @@ $queries = [
         usuario_id INTEGER NOT NULL,
         descricao TEXT NOT NULL,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );",
+    "CREATE TABLE IF NOT EXISTS lembretes_enviados (
+        tarefa_id INTEGER NOT NULL,
+        momento INTEGER NOT NULL,
+        PRIMARY KEY (tarefa_id, momento)
     );"
 ];
 
@@ -99,6 +104,11 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS alteracoes (
     usuario_id INTEGER NOT NULL,
     descricao TEXT NOT NULL,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);");
+$pdo->exec("CREATE TABLE IF NOT EXISTS lembretes_enviados (
+    tarefa_id INTEGER NOT NULL,
+    momento INTEGER NOT NULL,
+    PRIMARY KEY (tarefa_id, momento)
 );");
 
 echo "Banco de dados inicializado com sucesso.\n";

--- a/send_reminders.php
+++ b/send_reminders.php
@@ -1,0 +1,47 @@
+<?php
+require 'config.php';
+
+function enviarMensagemWhatsApp($numero, $mensagem){
+    global $whatsappConfig;
+    $url = $whatsappConfig['endpoint'] . '/' . $whatsappConfig['sessionId'];
+    $payload = json_encode([
+        'chatId'      => $numero . '@c.us',
+        'contentType' => 'string',
+        'content'     => $mensagem
+    ]);
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Content-Type: application/json',
+        'x-api-key: ' . $whatsappConfig['apiKey']
+    ]);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_exec($ch);
+    curl_close($ch);
+}
+
+$intervalos = [30, 20, 10];
+$sql = "SELECT t.id, t.titulo, t.detalhes, t.data_hora_agendamento, c.nome AS cliente, t.tipo_atendimento
+        FROM tarefas t LEFT JOIN clientes c ON t.cliente_id = c.id
+        WHERE t.status = 'Agendado' AND t.data_hora_agendamento IS NOT NULL";
+$tarefas = $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+
+foreach ($tarefas as $tarefa) {
+    $ag = new DateTime($tarefa['data_hora_agendamento']);
+    $diff = floor(($ag->getTimestamp() - time()) / 60);
+    foreach ($intervalos as $min) {
+        if ($diff == $min) {
+            $stmt = $pdo->prepare('SELECT COUNT(*) FROM lembretes_enviados WHERE tarefa_id = ? AND momento = ?');
+            $stmt->execute([$tarefa['id'], $min]);
+            if (!$stmt->fetchColumn()) {
+                $msg = "*{$tarefa['titulo']}*\n*{$tarefa['detalhes']}*\nPassando para lembrar do agendamento da tarefa para *{$tarefa['data_hora_agendamento']}*, para o cliente *{$tarefa['cliente']}*, o atendimento vai ser *{$tarefa['tipo_atendimento']}*.";
+                foreach ($whatsappConfig['numbers'] as $num) {
+                    enviarMensagemWhatsApp($num, $msg);
+                }
+                $ins = $pdo->prepare('INSERT INTO lembretes_enviados (tarefa_id, momento) VALUES (?, ?)');
+                $ins->execute([$tarefa['id'], $min]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add WhatsApp API configuration
- add table to control sent reminders
- update DB initialization with the new table
- script `send_reminders.php` to send scheduled WhatsApp messages
- document reminder script in README

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c4cb8cc4083259f4113d9dd60a75c