### PR TITLE
Adiciona lembretes automaticos

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,6 @@ sempre que qualquer página carrega o arquivo `config.php`.
 
 ### Lembretes de agendamento
 O script `send_reminders.php` envia mensagens de WhatsApp quando uma tarefa
-agendada está a 30, 20 ou 10 minutos de iniciar. Para utilizá‑lo,
-agende a execução desse arquivo via `cron` ou ferramenta similar.
+agendada está a 30, 20 ou 10 minutos de iniciar. As páginas do sistema agora
+chamam esse script automaticamente a cada minuto, mas é possível também
+agendá‑lo via `cron` ou ferramenta similar.

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -42,6 +42,10 @@ function atualizarKanban(callback){
 
 $(function() {
     setInterval(atualizarKanban, 5000); /*5000=Para Atualizar em 5 segunos */
+    // Chama o script de lembretes a cada minuto
+    setInterval(function(){
+        $.get('send_reminders.php');
+    }, 60000);
 
     $('#novaTarefaModal').on('show.bs.modal', function(){
         $('#novaTarefaForm')[0].reset();

--- a/index.php
+++ b/index.php
@@ -519,6 +519,6 @@ $usuarios = $pdo->query('SELECT id, nome FROM usuarios')->fetchAll(PDO::FETCH_AS
 <script>
 var clientesData = <?php echo json_encode($clientes); ?>;
 </script>
-<script src="assets/js/app.js?v=1.0.8"></script>
+<script src="assets/js/app.js?v=1.0.9"></script>
 </body>
 </html>


### PR DESCRIPTION
## Resumo
- aciona `send_reminders.php` a cada minuto via JavaScript
- ajusta versao do `app.js` no HTML
- documenta execucao automatica no README

## Testes
- `php -l index.php` *(falhou: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c53b9c4b88325a2acee2e3b9a36aa