### PR TITLE
Add manual WhatsApp send and log result

### DIFF
--- a/detalhes_tarefa.php
+++ b/detalhes_tarefa.php
@@ -105,7 +105,10 @@ $comentarios = $com->fetchAll(PDO::FETCH_ASSOC);
     </div>
     <div class="mb-3" id="campoAgendamento" style="display:none;">
       <label class="form-label">Data e Hora de Agendamento</label>
-      <input type="datetime-local" class="form-control" name="data_hora_agendamento" value="<?= $tarefa['data_hora_agendamento'] ? date('Y-m-d\TH:i', strtotime($tarefa['data_hora_agendamento'])) : '' ?>">
+      <div class="input-group">
+        <input type="datetime-local" class="form-control" name="data_hora_agendamento" value="<?= $tarefa['data_hora_agendamento'] ? date('Y-m-d\TH:i', strtotime($tarefa['data_hora_agendamento'])) : '' ?>">
+        <button class="btn btn-warning" type="button" id="btnEnviarMensagem">Enviar Mensagem</button>
+      </div>
     </div>
     <button type="submit" class="btn btn-secondary">Salvar Situação</button>
   </form>
@@ -159,6 +162,17 @@ $comentarios = $com->fetchAll(PDO::FETCH_ASSOC);
       }
       toggleAgendamento();
       $('#formStatus select[name=status]').on('change', toggleAgendamento);
+
+      $('#btnEnviarMensagem').on('click', function(){
+          var id = $('#formTarefaDetalhes input[name=id]').val();
+          $.post('send_message.php', {id: id}, function(resp){
+              if(resp.success){
+                  Swal.fire('Sucesso','Mensagem enviada com sucesso.','success');
+              } else {
+                  Swal.fire('Erro','Falha ao enviar mensagem: '+resp.message,'error');
+              }
+          }, 'json');
+      });
 
     $('#detClienteDropdownMenu').on('click', 'a.dropdown-item', function(e){
         e.preventDefault();

--- a/funcoes.php
+++ b/funcoes.php
@@ -3,4 +3,27 @@ function registrarAlteracao(PDO $pdo, $tarefaId, $usuarioId, $descricao){
     $stmt = $pdo->prepare('INSERT INTO alteracoes (tarefa_id, usuario_id, descricao, created_at) VALUES (?, ?, ?, ?)');
     $stmt->execute([$tarefaId, $usuarioId, $descricao, date('Y-m-d H:i:s')]);
 }
+
+function enviarMensagemWhatsApp($numero, $mensagem, &$httpCode = null){
+    global $whatsappConfig;
+    $url = $whatsappConfig['endpoint'] . '/' . $whatsappConfig['sessionId'];
+    $payload = json_encode([
+        'chatId'      => $numero . '@c.us',
+        'contentType' => 'string',
+        'content'     => $mensagem
+    ]);
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Content-Type: application/json',
+        'x-api-key: ' . $whatsappConfig['apiKey']
+    ]);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $error = curl_error($ch);
+    curl_close($ch);
+    return $error;
+}
 ?>

--- a/send_message.php
+++ b/send_message.php
@@ -1,0 +1,37 @@
+<?php
+require 'auth.php';
+require 'funcoes.php';
+
+$id = $_POST['id'] ?? 0;
+if (!$id) {
+    echo json_encode(['success' => false, 'message' => 'ID inválido']);
+    exit;
+}
+
+$stmt = $pdo->prepare("SELECT t.titulo, t.detalhes, t.data_hora_agendamento, c.nome AS cliente, t.tipo_atendimento FROM tarefas t LEFT JOIN clientes c ON t.cliente_id = c.id WHERE t.id = ?");
+$stmt->execute([$id]);
+$tarefa = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$tarefa) {
+    echo json_encode(['success' => false, 'message' => 'Tarefa não encontrada']);
+    exit;
+}
+
+$msg = "*{$tarefa['titulo']}*\n*{$tarefa['detalhes']}*\nPassando para lembrar do agendamento da tarefa para *{$tarefa['data_hora_agendamento']}*, para o cliente *{$tarefa['cliente']}*, o atendimento vai ser *{$tarefa['tipo_atendimento']}*.";
+
+$erroEnvio = '';
+$codigo = 0;
+foreach ($whatsappConfig['numbers'] as $num) {
+    $erro = enviarMensagemWhatsApp($num, $msg, $codigo);
+    if ($codigo != 200) {
+        $erroEnvio = $erro ?: 'HTTP ' . $codigo;
+    }
+}
+
+if ($erroEnvio === '') {
+    registrarAlteracao($pdo, $id, $_SESSION['usuario_id'], 'Mensagem de Agendamento enviada com Sucesso');
+    echo json_encode(['success' => true]);
+} else {
+    registrarAlteracao($pdo, $id, $_SESSION['usuario_id'], 'Erro ao enviar mensagem: ' . $erroEnvio);
+    echo json_encode(['success' => false, 'message' => $erroEnvio]);
+}
+

--- a/send_reminders.php
+++ b/send_reminders.php
@@ -1,25 +1,6 @@
 <?php
-require 'config.php';
-
-function enviarMensagemWhatsApp($numero, $mensagem){
-    global $whatsappConfig;
-    $url = $whatsappConfig['endpoint'] . '/' . $whatsappConfig['sessionId'];
-    $payload = json_encode([
-        'chatId'      => $numero . '@c.us',
-        'contentType' => 'string',
-        'content'     => $mensagem
-    ]);
-    $ch = curl_init($url);
-    curl_setopt($ch, CURLOPT_POST, true);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, [
-        'Content-Type: application/json',
-        'x-api-key: ' . $whatsappConfig['apiKey']
-    ]);
-    curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_exec($ch);
-    curl_close($ch);
-}
+require 'auth.php';
+require 'funcoes.php';
 
 $intervalos = [30, 20, 10];
 $sql = "SELECT t.id, t.titulo, t.detalhes, t.data_hora_agendamento, c.nome AS cliente, t.tipo_atendimento
@@ -36,11 +17,21 @@ foreach ($tarefas as $tarefa) {
             $stmt->execute([$tarefa['id'], $min]);
             if (!$stmt->fetchColumn()) {
                 $msg = "*{$tarefa['titulo']}*\n*{$tarefa['detalhes']}*\nPassando para lembrar do agendamento da tarefa para *{$tarefa['data_hora_agendamento']}*, para o cliente *{$tarefa['cliente']}*, o atendimento vai ser *{$tarefa['tipo_atendimento']}*.";
+                $erroEnvio = '';
+                $codigo = 0;
                 foreach ($whatsappConfig['numbers'] as $num) {
-                    enviarMensagemWhatsApp($num, $msg);
+                    $erro = enviarMensagemWhatsApp($num, $msg, $codigo);
+                    if ($codigo != 200) {
+                        $erroEnvio = $erro ?: 'HTTP ' . $codigo;
+                    }
                 }
                 $ins = $pdo->prepare('INSERT INTO lembretes_enviados (tarefa_id, momento) VALUES (?, ?)');
                 $ins->execute([$tarefa['id'], $min]);
+                if ($erroEnvio === '') {
+                    registrarAlteracao($pdo, $tarefa['id'], $_SESSION['usuario_id'], 'Mensagem de Agendamento enviada com Sucesso');
+                } else {
+                    registrarAlteracao($pdo, $tarefa['id'], $_SESSION['usuario_id'], 'Erro ao enviar mensagem: ' . $erroEnvio);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add helper to send WhatsApp messages
- add API endpoint `send_message.php`
- log success or error for scheduled and manual message sends
- add button to manually send WhatsApp message in task details

## Testing
- `php -l funcoes.php` *(fails: php not found)*
- `php -l send_message.php` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c581011008325bcade825cfe7e56c