### PR TITLE
Melhoria na formatação de data da mensagem

### DIFF
--- a/send_message.php
+++ b/send_message.php
@@ -16,7 +16,10 @@ if (!$tarefa) {
     exit;
 }
 
-$msg = "*{$tarefa['titulo']}*\n*{$tarefa['detalhes']}*\nPassando para lembrar do agendamento da tarefa para *{$tarefa['data_hora_agendamento']}*, para o cliente *{$tarefa['cliente']}*, o atendimento vai ser *{$tarefa['tipo_atendimento']}*.";
+$dataFormatada = $tarefa['data_hora_agendamento']
+    ? date('d/m/Y H:i', strtotime($tarefa['data_hora_agendamento']))
+    : '';
+$msg = "*{$tarefa['titulo']}*\n*{$tarefa['detalhes']}*\nPassando para lembrar do agendamento da tarefa para *{$dataFormatada}*, para o cliente *{$tarefa['cliente']}*, o atendimento vai ser *{$tarefa['tipo_atendimento']}*.";
 
 $erroEnvio = '';
 $codigo = 0;


### PR DESCRIPTION
## Resumo
- formatar `data_hora_agendamento` antes de compor a mensagem enviada

## Testes
- `php -l send_message.php` *(falhou: php não instalado)*

------
https://chatgpt.com/codex/tasks/task_e_686c8a3c8f848325ad11e6d181b6555d